### PR TITLE
fix: Keep one unresponsive TV from freezing the app

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts run inside the Linux image. Checked out with CRLF (the default on
+# Windows) the shebang becomes `#!/bin/sh\r` and the container fails to start with
+# "exec /entrypoint.sh: no such file or directory".
+*.sh text eol=lf

--- a/.github/workflows/build_image.yaml
+++ b/.github/workflows/build_image.yaml
@@ -9,6 +9,13 @@ on:
         description: 'Version or tag to use for build'
         required: false
         type: string
+  # Lets a maintainer publish an image without waiting for a release.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Extra tag to publish next to latest (optional)'
+        required: false
+        type: string
 
 env:
   REGISTRY: ghcr.io
@@ -64,9 +71,12 @@ jobs:
         uses: docker/metadata-action@v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # github.ref_name is not usable as a fallback: a branch like feat/foo would
+          # produce an invalid tag. type=sha covers the manual runs instead.
           tags: |
             type=raw,value=latest
-            type=raw,value=${{ inputs.version || github.ref_name }}
+            type=raw,value=${{ inputs.version }},enable=${{ inputs.version != '' }}
+            type=sha,format=short
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.19.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install backend
+        run: pip install -e ".[test]"
+
+      - name: Run tests
+        run: pytest -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      # `npm ci` is what the release build uses, so a stale lockfile fails here
+      # instead of on release day.
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,6 @@ RUN chmod +x /entrypoint.sh
 # Run entrypoint.sh for db migrations, ..
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["gunicorn", "app:app", "--bind", "0.0.0.0:8000"]
+# Several workers so one TV that stops answering cannot freeze the whole app, and a
+# timeout above FRAME_TV_UPLOAD_DEADLINE so a legitimately slow upload is not killed.
+CMD ["sh", "-c", "exec gunicorn app:app --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-4} --timeout ${GUNICORN_TIMEOUT:-180}"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ Docker Compose (recommended):
 1. `docker compose pull`
 2. `docker compose up -d`
 
+# Configuration
+
+All optional, with sensible defaults. Set them as environment variables on the container.
+
+| Variable | Default | What it does |
+| --- | --- | --- |
+| `GUNICORN_WORKERS` | `4` | Worker processes. More than one keeps a slow TV from blocking the whole app. |
+| `GUNICORN_TIMEOUT` | `180` | Seconds before gunicorn kills a worker. Keep it above `FRAME_TV_UPLOAD_DEADLINE`. |
+| `FRAME_TV_SOCKET_TIMEOUT` | `8` | Socket timeout for a single read from the TV. |
+| `FRAME_TV_CALL_DEADLINE` | `20` | Seconds a normal TV request may take before it is given up on. |
+| `FRAME_TV_UPLOAD_DEADLINE` | `120` | Same, for image uploads, which push the whole file to the TV. |
+| `FRAME_TV_PAIRING_TIMEOUT` | `45` | How long adding a TV waits for the pairing prompt to be accepted. |
+| `FRAME_TV_DOWN_COOLDOWN` | `30` | Seconds a TV is skipped after it failed to answer. |
+| `FRAME_TV_MAX_PARALLEL_CALLS` | `8` | Concurrent TV requests per worker. |
+
+# Tests
+
+```
+pip install -e ".[test]"
+pytest
+```
+
 # Troubleshooting
 ## Errors when uploading images to the TV:
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ pytest
 ```
 
 # Troubleshooting
+
+## The TV gallery shows placeholders instead of thumbnails
+
+The TV stopped answering. Every request to a TV is given a deadline, and a TV that misses
+it is skipped for `FRAME_TV_DOWN_COOLDOWN` seconds so one silent set cannot tie up the
+whole app — the page then falls back to whatever thumbnails are already cached on disk.
+
+Deliberate actions (playing an image, deleting one, uploading) ignore that cooldown and
+still try, so the TV waking up is noticed immediately. If it persists, check that the TV is
+on and reachable, then look for a single `Timeout after …` line in the logs: the skipped
+requests that follow are deliberately silent.
+
 ## Errors when uploading images to the TV:
 
 -> Check that the TV is on and has enough free storage space. When the storage space for art images is full, the upload fails. 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The TV stopped answering. Every request to a TV is given a deadline, and a TV th
 it is skipped for `FRAME_TV_DOWN_COOLDOWN` seconds so one silent set cannot tie up the
 whole app — the page then falls back to whatever thumbnails are already cached on disk.
 
+A Frame TV serves a single art channel, so requests to one TV are serialised: opening a
+second connection while another is still being established makes the set reject both. The
+whole page of thumbnails is fetched in one round trip for the same reason.
+
 Deliberate actions (playing an image, deleting one, uploading) ignore that cooldown and
 still try, so the TV waking up is noticed immediately. If it persists, check that the TV is
 on and reachable, then look for a single `Timeout after …` line in the logs: the skipped

--- a/app.py
+++ b/app.py
@@ -43,6 +43,7 @@ from utils.frame_tv import (
     FrameTVError,
     FrameTVConnectionError,
     FrameTVTimeoutError,
+    FrameTVUnavailableError,
     delete_all_images_from_tv,
     get_tv_gallery_images,
     delete_tv_image,
@@ -604,6 +605,9 @@ def api_get_tv_gallery(ip):
     try:
         images = get_tv_gallery_images(ip, token=tv.token)
         return jsonify({'images': images, 'tv_ip': ip})
+    except FrameTVUnavailableError as e:
+        app.logger.info('Skipping TV gallery: %s', e)
+        return jsonify({'error': 'TV is unavailable', 'tv_unavailable': True}), 503
     except FrameTVTimeoutError as e:
         _log_exception('Timeout while fetching TV gallery', e)
         return jsonify({'error': 'TV request timed out'}), 504
@@ -650,12 +654,17 @@ def api_tv_gallery_thumbnail(ip, content_id):
         if not thumbnail:
             return jsonify({'error': 'Thumbnail not found'}), 404
         return Response(thumbnail, mimetype=_guess_image_mimetype(thumbnail))
+    except FrameTVUnavailableError as e:
+        # The circuit breaker refusing a call is the design working, and a gallery page
+        # trips it once per thumbnail. One line, no stack trace.
+        app.logger.info('Skipping TV thumbnail: %s', e)
+        return jsonify({'error': 'TV is unavailable', 'tv_unavailable': True}), 503
     except FrameTVTimeoutError as e:
         _log_exception('Timeout while fetching TV thumbnail', e)
-        return jsonify({'error': 'TV request timed out'}), 504
+        return jsonify({'error': 'TV request timed out', 'tv_unavailable': True}), 504
     except FrameTVConnectionError as e:
         _log_exception('TV connection failed while fetching thumbnail', e)
-        return jsonify({'error': 'TV is unavailable'}), 503
+        return jsonify({'error': 'TV is unavailable', 'tv_unavailable': True}), 503
     except Exception as e:
         _log_exception('Failed to fetch TV thumbnail', e)
         return jsonify({'error': 'Failed to fetch thumbnail'}), 500

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import base64
 from flask import Flask, render_template, request, redirect, url_for, flash, send_from_directory, jsonify, Response
 import os
 from werkzeug.utils import secure_filename
@@ -46,6 +47,7 @@ from utils.frame_tv import (
     FrameTVUnavailableError,
     delete_all_images_from_tv,
     get_tv_gallery_images,
+    get_tv_gallery_thumbnails,
     delete_tv_image,
     play_uploaded_content,
     get_tv_gallery_thumbnail,
@@ -642,6 +644,47 @@ def api_play_tv_image(ip, content_id):
     except Exception as e:
         _log_exception('Unexpected error playing TV image', e)
         return jsonify({'error': 'Unexpected error'}), 500
+
+@app.route("/api/tv/<ip>/gallery/thumbnails", methods=['POST'])
+def api_tv_gallery_thumbnails(ip):
+    """Return several thumbnails at once, as {content_id: base64}.
+
+    A Frame TV serves one art channel at a time, so asking for a page of thumbnails
+    one request at a time made the requests reject each other. This is one round trip.
+    """
+    tv = TV.query.filter_by(ip=ip).first()
+    if not tv:
+        return jsonify({'error': 'TV not found'}), 404
+
+    data = request.get_json(silent=True) or {}
+    content_ids = data.get('content_ids')
+    if not isinstance(content_ids, list) or not all(isinstance(c, str) and c for c in content_ids):
+        return jsonify({'error': 'content_ids must be a list of strings'}), 400
+    if len(content_ids) > 500:
+        return jsonify({'error': 'Too many content ids'}), 400
+    if not content_ids:
+        return jsonify({'thumbnails': {}})
+
+    try:
+        thumbnails = get_tv_gallery_thumbnails(ip, content_ids, token=tv.token)
+        return jsonify({
+            'thumbnails': {
+                cid: base64.b64encode(data).decode('ascii') for cid, data in thumbnails.items()
+            }
+        })
+    except FrameTVUnavailableError as e:
+        app.logger.info('Skipping TV thumbnails: %s', e)
+        return jsonify({'error': 'TV is unavailable', 'tv_unavailable': True}), 503
+    except FrameTVTimeoutError as e:
+        _log_exception('Timeout while fetching TV thumbnails', e)
+        return jsonify({'error': 'TV request timed out', 'tv_unavailable': True}), 504
+    except FrameTVConnectionError as e:
+        _log_exception('TV connection failed while fetching thumbnails', e)
+        return jsonify({'error': 'TV is unavailable', 'tv_unavailable': True}), 503
+    except Exception as e:
+        _log_exception('Failed to fetch TV thumbnails', e)
+        return jsonify({'error': 'Failed to fetch thumbnails'}), 500
+
 
 @app.route("/api/tv/<ip>/gallery/<content_id>/thumbnail", methods=['GET'])
 def api_tv_gallery_thumbnail(ip, content_id):

--- a/frontend/app/components/TVGalleryImageCard.tsx
+++ b/frontend/app/components/TVGalleryImageCard.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
 import { TrashIcon, PlayIcon, PhotoIcon } from "@heroicons/react/24/outline";
 import { Skeleton } from "~/components/ui/skeleton"
-import {
-  getTvGalleryThumbnailUrl,
-  type TVGalleryImage,
-} from "../utils/tvApi";
+import { type TVGalleryImage } from "../utils/tvApi";
 
 function Loader() {
   return (
@@ -17,12 +14,14 @@ function Loader() {
 type TVGalleryImageCardProps = {
   image: TVGalleryImage;
   selectedTvIp: string;
+  /** true while the parent is still batch-fetching the missing thumbnails */
+  thumbnailsLoading?: boolean;
   onPlay: (contentId: string) => void;
   onDelete: (contentId: string) => void;
   formatDate: (dateString: string) => string;
 };
 
-export default function TVGalleryImageCard({ image, selectedTvIp, onPlay, onDelete, formatDate }: TVGalleryImageCardProps) {
+export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoading, onPlay, onDelete, formatDate }: TVGalleryImageCardProps) {
   const [imgLoaded, setImgLoaded] = useState(false);
   const [imgError, setImgError] = useState(false);
   return (
@@ -30,33 +29,34 @@ export default function TVGalleryImageCard({ image, selectedTvIp, onPlay, onDele
       key={image.content_id}
       className="flex gap-4 p-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md transition-shadow"
     >
+      {/* The thumbnail always comes from the parent's single batched request. Letting the
+          <img> fall back to the per-image endpoint fired one TV websocket per card, which
+          is what used to pile up and starve the server when a TV stopped answering. */}
       <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
-        {!imgLoaded && !imgError && <Loader />}
-        <img
-          src={
-            image.thumbnail
-              ? `data:image/jpeg;base64,${image.thumbnail}`
-              : getTvGalleryThumbnailUrl(selectedTvIp, image.content_id)
-          }
-          alt={image.filename}
-          className="h-full w-full object-cover"
-          style={{ display: imgLoaded && !imgError ? "block" : "none" }}
-          onLoad={() => setImgLoaded(true)}
-          onError={(event) => {
-            setImgError(true);
-            event.currentTarget.style.display = "none";
-            const fallback = event.currentTarget.nextElementSibling as HTMLElement | null;
-            if (fallback) {
-              fallback.style.display = "flex";
-            }
-          }}
-        />
-        <div
-          className="absolute inset-0 hidden items-center justify-center text-gray-400"
-          style={{ display: imgError ? "flex" : "none" }}
-        >
-          <PhotoIcon className="h-8 w-8" />
-        </div>
+        {image.thumbnail ? (
+          <>
+            {!imgLoaded && !imgError && <Loader />}
+            <img
+              src={`data:image/jpeg;base64,${image.thumbnail}`}
+              alt={image.filename}
+              className="h-full w-full object-cover"
+              style={{ display: imgLoaded && !imgError ? "block" : "none" }}
+              onLoad={() => setImgLoaded(true)}
+              onError={() => setImgError(true)}
+            />
+            {imgError && (
+              <div className="absolute inset-0 flex items-center justify-center text-gray-400">
+                <PhotoIcon className="h-8 w-8" />
+              </div>
+            )}
+          </>
+        ) : thumbnailsLoading ? (
+          <Loader />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-gray-400" title="No preview available">
+            <PhotoIcon className="h-8 w-8" />
+          </div>
+        )}
       </div>
 
       <div className="flex-1 min-w-0 self-center">

--- a/frontend/app/routes/tvGallery.tsx
+++ b/frontend/app/routes/tvGallery.tsx
@@ -6,6 +6,7 @@ import TVGalleryImageCard from "~/components/TVGalleryImageCard";
 import { toast } from "sonner";
 import {
   deleteTvGalleryImage,
+  fetchTvGalleryThumbnails,
   getTvGalleryImages,
   getTvs,
   playTvGalleryImage,
@@ -18,6 +19,7 @@ export default function TVGallery() {
 
   const [images, setImages] = useState<TVGalleryImage[]>([]);
   const [loading, setLoading] = useState(false);
+  const [thumbnailsLoading, setThumbnailsLoading] = useState(false);
   const [selectedTvIp, setSelectedTvIp] = useState<string>(tvIp || "");
   const [tvs, setTvs] = useState<any[]>([]);
 
@@ -58,12 +60,15 @@ export default function TVGallery() {
       // Fetch missing thumbnails in background and update state when ready
       const missing = (tvImages || []).filter((i) => !i.thumbnail).map((i) => i.content_id);
       if (missing.length > 0) {
+        setThumbnailsLoading(true);
         (async () => {
           try {
-            const thumbs = await (await import("~/utils/tvApi")).fetchTvGalleryThumbnails(selectedTvIp, missing);
+            const thumbs = await fetchTvGalleryThumbnails(selectedTvIp, missing);
             setImages((prev) => prev.map((img) => ({ ...img, thumbnail: img.thumbnail || thumbs[img.content_id] || null })));
           } catch (err) {
             console.warn("Failed to batch-fetch thumbnails", err);
+          } finally {
+            setThumbnailsLoading(false);
           }
         })();
       }
@@ -71,6 +76,7 @@ export default function TVGallery() {
       console.error("Failed to fetch gallery:", error);
       toast.error("Failed to load TV gallery");
       setLoading(false);
+      setThumbnailsLoading(false);
     }
   };
 
@@ -150,6 +156,7 @@ export default function TVGallery() {
                   key={image.content_id}
                   image={image}
                   selectedTvIp={selectedTvIp}
+                  thumbnailsLoading={thumbnailsLoading}
                   onPlay={handlePlayImage}
                   onDelete={handleDeleteImage}
                   formatDate={formatDate}

--- a/frontend/app/utils/tvApi.ts
+++ b/frontend/app/utils/tvApi.ts
@@ -102,13 +102,20 @@ export function getTvGalleryThumbnailUrl(ip: string, contentId: string) {
 export async function fetchTvGalleryThumbnails(ip: string, contentIds: string[], concurrency = 6): Promise<Record<string, string>> {
   const out: Record<string, string> = {};
   let idx = 0;
+  // A TV that stopped answering answers nothing: once one request says so, asking for
+  // the remaining hundred only fills the log.
+  let tvUnavailable = false;
 
   async function worker() {
-    while (idx < contentIds.length) {
+    while (idx < contentIds.length && !tvUnavailable) {
       const i = idx++;
       const cid = contentIds[i];
       try {
         const res = await fetch(getTvGalleryThumbnailUrl(ip, cid));
+        if (res.status === 503 || res.status === 504) {
+          tvUnavailable = true;
+          break;
+        }
         if (!res.ok) continue;
         const blob = await res.blob();
         const arrayBuffer = await blob.arrayBuffer();

--- a/frontend/app/utils/tvApi.ts
+++ b/frontend/app/utils/tvApi.ts
@@ -98,46 +98,28 @@ export function getTvGalleryThumbnailUrl(ip: string, contentId: string) {
   return `${API_BASE}/api/tv/${encodeURIComponent(ip)}/gallery/${encodeURIComponent(contentId)}/thumbnail`;
 }
 
-// Fetch thumbnails in batches with limited concurrency. Returns map contentId -> base64 string
-export async function fetchTvGalleryThumbnails(ip: string, contentIds: string[], concurrency = 6): Promise<Record<string, string>> {
-  const out: Record<string, string> = {};
-  let idx = 0;
-  // A TV that stopped answering answers nothing: once one request says so, asking for
-  // the remaining hundred only fills the log.
-  let tvUnavailable = false;
+/**
+ * Fetch thumbnails for a whole page in one request. Returns map contentId -> base64.
+ *
+ * This used to fire one request per image with six in flight, but a Frame TV serves a
+ * single art channel: the parallel requests were rejecting each other rather than
+ * merely queueing. The backend now does the batch in one round trip.
+ */
+export async function fetchTvGalleryThumbnails(ip: string, contentIds: string[]): Promise<Record<string, string>> {
+  if (contentIds.length === 0) return {};
 
-  async function worker() {
-    while (idx < contentIds.length && !tvUnavailable) {
-      const i = idx++;
-      const cid = contentIds[i];
-      try {
-        const res = await fetch(getTvGalleryThumbnailUrl(ip, cid));
-        if (res.status === 503 || res.status === 504) {
-          tvUnavailable = true;
-          break;
-        }
-        if (!res.ok) continue;
-        const blob = await res.blob();
-        const arrayBuffer = await blob.arrayBuffer();
-        const bytes = new Uint8Array(arrayBuffer);
-        // convert to base64
-        let binary = '';
-        const chunkSize = 0x8000;
-        for (let offset = 0; offset < bytes.length; offset += chunkSize) {
-          const slice = bytes.subarray(offset, Math.min(offset + chunkSize, bytes.length));
-          binary += String.fromCharCode.apply(null, Array.from(slice));
-        }
-        out[cid] = btoa(binary);
-      } catch (e) {
-        // ignore failures per-thumbnail
-      }
-    }
+  const res = await fetch(`${API_BASE}/api/tv/${encodeURIComponent(ip)}/gallery/thumbnails`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content_ids: contentIds }),
+  });
+  if (!res.ok) {
+    // A silent TV is not an error worth shouting about: the cards fall back to a
+    // placeholder, and the cached thumbnails already came with the gallery listing.
+    if (res.status === 503 || res.status === 504) return {};
+    throw new TVError('Failed to load TV thumbnails', res.status);
   }
-
-  const workers = [];
-  for (let i = 0; i < Math.min(concurrency, contentIds.length); i++) workers.push(worker());
-  await Promise.all(workers);
-  return out;
+  return (await res.json()).thumbnails || {};
 }
 
 export async function playTvGalleryImage(ip: string, contentId: string) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3162,49 +3162,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
-      "integrity": "sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/remapping": "^2.3.4",
-        "enhanced-resolve": "^5.18.3",
-        "jiti": "^2.6.1",
-        "lightningcss": "1.30.2",
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.18"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.18.tgz",
-      "integrity": "sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.18",
-        "@tailwindcss/oxide-darwin-x64": "4.1.18",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.18",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.18",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.18",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.18",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.18",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.18"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.18.tgz",
-      "integrity": "sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -3215,13 +3215,13 @@
         "android"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.18.tgz",
-      "integrity": "sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -3232,13 +3232,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.18.tgz",
-      "integrity": "sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -3249,13 +3249,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.18.tgz",
-      "integrity": "sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -3266,13 +3266,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.18.tgz",
-      "integrity": "sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -3283,81 +3283,93 @@
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.18.tgz",
-      "integrity": "sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.18.tgz",
-      "integrity": "sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.18.tgz",
-      "integrity": "sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.18.tgz",
-      "integrity": "sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.18.tgz",
-      "integrity": "sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -3373,81 +3385,21 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.0",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.4.0"
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
-      "integrity": "sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -3458,13 +3410,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.18.tgz",
-      "integrity": "sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -3475,22 +3427,22 @@
         "win32"
       ],
       "engines": {
-        "node": ">= 10"
+        "node": ">= 20"
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
-      "integrity": "sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.1.18",
-        "@tailwindcss/oxide": "4.1.18",
-        "tailwindcss": "4.1.18"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
       },
       "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7"
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
     "node_modules/@ts-morph/common": {
@@ -4554,14 +4506,14 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -5551,9 +5503,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5661,9 +5613,9 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
-      "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -5677,23 +5629,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.30.2",
-        "lightningcss-darwin-arm64": "1.30.2",
-        "lightningcss-darwin-x64": "1.30.2",
-        "lightningcss-freebsd-x64": "1.30.2",
-        "lightningcss-linux-arm-gnueabihf": "1.30.2",
-        "lightningcss-linux-arm64-gnu": "1.30.2",
-        "lightningcss-linux-arm64-musl": "1.30.2",
-        "lightningcss-linux-x64-gnu": "1.30.2",
-        "lightningcss-linux-x64-musl": "1.30.2",
-        "lightningcss-win32-arm64-msvc": "1.30.2",
-        "lightningcss-win32-x64-msvc": "1.30.2"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.30.2.tgz",
-      "integrity": "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -5712,9 +5664,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.30.2.tgz",
-      "integrity": "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -5733,9 +5685,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.30.2.tgz",
-      "integrity": "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -5754,9 +5706,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.30.2.tgz",
-      "integrity": "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -5775,9 +5727,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.30.2.tgz",
-      "integrity": "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -5796,13 +5748,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.30.2.tgz",
-      "integrity": "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5817,13 +5772,16 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.30.2.tgz",
-      "integrity": "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5838,13 +5796,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.30.2.tgz",
-      "integrity": "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5859,13 +5820,16 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.30.2.tgz",
-      "integrity": "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5880,9 +5844,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.30.2.tgz",
-      "integrity": "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -5901,9 +5865,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.30.2",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.30.2.tgz",
-      "integrity": "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -7655,16 +7619,16 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
-      "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8133,279 +8097,6 @@
       },
       "peerDependencies": {
         "vite": "*"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,5 +23,8 @@ dependencies = [
     "Pillow",
 ]
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [tool.setuptools.packages.find]
 include = ["app*"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+import sys
+import tempfile
+
+# Keep uploads, the database and the thumbnail cache out of the working tree. This has
+# to happen before app/utils.frame_tv are imported, since both read it at import time.
+os.environ.setdefault(
+    "FRAME_TV_DATA", os.path.join(tempfile.gettempdir(), "frametv-art-gallery-tests")
+)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tests/test_frame_tv_timeouts.py
+++ b/tests/test_frame_tv_timeouts.py
@@ -14,7 +14,11 @@ import time
 import pytest
 
 from utils import frame_tv
-from utils.frame_tv import FrameTVConnectionError, FrameTVTimeoutError
+from utils.frame_tv import (
+    FrameTVConnectionError,
+    FrameTVTimeoutError,
+    FrameTVUnavailableError,
+)
 
 # Long enough to outlive the deadlines below, short enough that the worker threads are
 # gone before the interpreter shuts down.
@@ -68,7 +72,7 @@ def test_unresponsive_tv_is_skipped_during_the_cooldown():
 
     calls = []
     started = time.monotonic()
-    with pytest.raises(FrameTVConnectionError):
+    with pytest.raises(FrameTVUnavailableError):
         frame_tv._tv_call("192.0.2.3", "testing", lambda session: calls.append(1), open_remote=False)
     assert calls == [], "the TV should not have been contacted during the cooldown"
     assert time.monotonic() - started < 1
@@ -96,6 +100,24 @@ def test_the_cooldown_is_shared_between_processes():
     assert frame_tv._tv_cooldown_remaining("192.0.2.8") > 0
     marker.unlink()
     assert frame_tv._tv_cooldown_remaining("192.0.2.8") == 0
+
+
+def test_a_deliberate_action_still_reaches_a_tv_in_cooldown():
+    """A failed thumbnail must not stop someone from pressing play on that TV."""
+    frame_tv._mark_tv_down("192.0.2.9")
+
+    with pytest.raises(FrameTVUnavailableError):
+        frame_tv._tv_call("192.0.2.9", "fetching a thumbnail from", lambda s: "never", open_remote=False)
+
+    assert frame_tv._tv_call(
+        "192.0.2.9", "playing an image on", lambda s: "played",
+        open_remote=False, skip_when_down=False,
+    ) == "played"
+
+
+def test_the_unavailable_error_stays_a_connection_error():
+    """Existing handlers catch FrameTVConnectionError; the new type must not escape them."""
+    assert issubclass(FrameTVUnavailableError, FrameTVConnectionError)
 
 
 def test_tv_errors_are_not_swallowed_as_connection_errors():

--- a/tests/test_frame_tv_timeouts.py
+++ b/tests/test_frame_tv_timeouts.py
@@ -115,6 +115,51 @@ def test_a_deliberate_action_still_reaches_a_tv_in_cooldown():
     ) == "played"
 
 
+def test_one_tv_serves_one_call_at_a_time():
+    """Concurrent art channels make a Frame TV reject them, so calls must serialise."""
+    overlapping = []
+    active = 0
+    guard = threading.Lock()
+
+    def slow(_session):
+        nonlocal active
+        with guard:
+            active += 1
+            overlapping.append(active)
+        time.sleep(0.3)
+        with guard:
+            active -= 1
+        return "done"
+
+    def call():
+        frame_tv._tv_call("192.0.2.10", "testing", slow, open_remote=False)
+
+    threads = [threading.Thread(target=call) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert len(overlapping) == 4, "every call should have run"
+    assert max(overlapping) == 1, f"calls overlapped on one TV: {overlapping}"
+
+
+def test_a_second_tv_is_not_held_up_by_the_first():
+    started = time.monotonic()
+    holder = threading.Thread(
+        target=lambda: frame_tv._tv_call(
+            "192.0.2.11", "testing", lambda s: time.sleep(1), open_remote=False
+        )
+    )
+    holder.start()
+    time.sleep(0.1)
+    assert frame_tv._tv_call(
+        "192.0.2.12", "testing", lambda s: "free", open_remote=False
+    ) == "free"
+    assert time.monotonic() - started < 1, "a different TV should not wait"
+    holder.join(timeout=10)
+
+
 def test_the_unavailable_error_stays_a_connection_error():
     """Existing handlers catch FrameTVConnectionError; the new type must not escape them."""
     assert issubclass(FrameTVUnavailableError, FrameTVConnectionError)

--- a/tests/test_frame_tv_timeouts.py
+++ b/tests/test_frame_tv_timeouts.py
@@ -1,0 +1,119 @@
+"""Checks that a TV which stops answering cannot block a request forever.
+
+samsungtvws waits on recv() without an overall timeout, so utils.frame_tv wraps every
+TV call in a deadline. These tests exercise that wrapper without touching the network:
+`open_remote=False` skips the handshake and the action stands in for a stuck read.
+
+Run with: pytest tests/test_frame_tv_timeouts.py
+"""
+
+import shutil
+import threading
+import time
+
+import pytest
+
+from utils import frame_tv
+from utils.frame_tv import FrameTVConnectionError, FrameTVTimeoutError
+
+# Long enough to outlive the deadlines below, short enough that the worker threads are
+# gone before the interpreter shuts down.
+STUCK = 3
+
+
+@pytest.fixture(autouse=True)
+def clear_cooldowns():
+    shutil.rmtree(frame_tv.TV_DOWN_DIR, ignore_errors=True)
+    yield
+    shutil.rmtree(frame_tv.TV_DOWN_DIR, ignore_errors=True)
+
+
+def test_stuck_call_gives_up_at_the_deadline():
+    started = time.monotonic()
+    with pytest.raises(FrameTVTimeoutError):
+        frame_tv._tv_call(
+            "192.0.2.1",
+            "testing",
+            lambda session: time.sleep(STUCK),
+            deadline=1,
+            open_remote=False,
+        )
+    assert time.monotonic() - started < STUCK, "the call outlived its deadline"
+
+
+def test_expired_call_closes_the_session(monkeypatch):
+    """Closing the sockets is what releases the read blocking the worker thread."""
+    closed = threading.Event()
+    original_close = frame_tv._TVSession.close
+
+    def spy(self):
+        closed.set()
+        original_close(self)
+
+    monkeypatch.setattr(frame_tv._TVSession, "close", spy)
+
+    with pytest.raises(FrameTVTimeoutError):
+        frame_tv._tv_call(
+            "192.0.2.2", "testing", lambda session: time.sleep(STUCK), deadline=1, open_remote=False
+        )
+    assert closed.is_set(), "the sockets were left open, so the stuck read is never released"
+
+
+def test_unresponsive_tv_is_skipped_during_the_cooldown():
+    """The second call must fail immediately instead of hanging like the first."""
+    with pytest.raises(FrameTVTimeoutError):
+        frame_tv._tv_call(
+            "192.0.2.3", "testing", lambda session: time.sleep(STUCK), deadline=1, open_remote=False
+        )
+
+    calls = []
+    started = time.monotonic()
+    with pytest.raises(FrameTVConnectionError):
+        frame_tv._tv_call("192.0.2.3", "testing", lambda session: calls.append(1), open_remote=False)
+    assert calls == [], "the TV should not have been contacted during the cooldown"
+    assert time.monotonic() - started < 1
+
+    # ...and another TV is unaffected by its neighbour being down.
+    assert frame_tv._tv_call("192.0.2.4", "testing", lambda session: "fine", open_remote=False) == "fine"
+
+
+def test_a_successful_call_clears_the_cooldown():
+    frame_tv._mark_tv_down("192.0.2.5")
+    assert frame_tv._tv_cooldown_remaining("192.0.2.5") > 0
+    frame_tv._mark_tv_up("192.0.2.5")
+    assert frame_tv._tv_cooldown_remaining("192.0.2.5") == 0
+    assert frame_tv._tv_call("192.0.2.5", "testing", lambda session: "ok", open_remote=False) == "ok"
+
+
+def test_the_cooldown_is_shared_between_processes():
+    """gunicorn runs several workers; an in-memory cooldown would only teach one of them."""
+    frame_tv._mark_tv_down("192.0.2.8")
+    marker = frame_tv._tv_down_marker("192.0.2.8")
+    assert marker.is_file(), "the cooldown must survive outside this process"
+    assert frame_tv.TV_DOWN_DIR in marker.parents
+
+    # A separate reader of the same directory sees the TV as down.
+    assert frame_tv._tv_cooldown_remaining("192.0.2.8") > 0
+    marker.unlink()
+    assert frame_tv._tv_cooldown_remaining("192.0.2.8") == 0
+
+
+def test_tv_errors_are_not_swallowed_as_connection_errors():
+    """A TV that answers "no" must stay distinguishable from a TV that does not answer."""
+
+    class TVSaidNo(Exception):
+        pass
+
+    def refuse(session):
+        raise TVSaidNo("bad content id")
+
+    with pytest.raises(TVSaidNo):
+        frame_tv._tv_call("192.0.2.6", "testing", refuse, open_remote=False)
+    assert frame_tv._tv_cooldown_remaining("192.0.2.6") == 0, "the TV is alive, do not skip it"
+
+    def unreachable(session):
+        raise OSError("connection refused")
+
+    with pytest.raises(FrameTVConnectionError):
+        frame_tv._tv_call("192.0.2.7", "testing", unreachable, open_remote=False)
+    assert frame_tv._tv_cooldown_remaining("192.0.2.7") > 0

--- a/utils/frame_tv.py
+++ b/utils/frame_tv.py
@@ -1,4 +1,6 @@
+import contextlib
 import socket
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from typing import Any, Callable, Dict, List, Optional
@@ -155,9 +157,12 @@ _TV_EXECUTOR = ThreadPoolExecutor(
 TV_DOWN_DIR = _DATA_DIR.joinpath('instance', 'tv_down')
 
 
+def _safe_ip(ip: str) -> str:
+    return "".join(ch if ch.isalnum() or ch in "-._" else "_" for ch in ip)
+
+
 def _tv_down_marker(ip: str) -> Path:
-    safe = "".join(ch if ch.isalnum() or ch in "-._" else "_" for ch in ip)
-    return TV_DOWN_DIR.joinpath(f"tv-{safe}")
+    return TV_DOWN_DIR.joinpath(f"tv-{_safe_ip(ip)}")
 
 
 def _tv_cooldown_remaining(ip: str) -> float:
@@ -181,6 +186,63 @@ def _mark_tv_up(ip: str) -> None:
         _tv_down_marker(ip).unlink()
     except OSError:
         pass
+
+
+# A Frame TV serves a single art channel. Opening a second one while another is still
+# connecting makes the set announce `ms.channel.clientConnect`, which samsungtvws raises
+# as a connection failure — so parallel requests to one TV do not queue, they break each
+# other. gunicorn runs several workers, hence a file lock on top of the in-process one.
+try:
+    import fcntl  # POSIX only; the published image runs Linux
+except ImportError:  # pragma: no cover - Windows development
+    fcntl = None
+
+TV_LOCK_DIR = _DATA_DIR.joinpath('instance', 'tv_locks')
+_LOCAL_TV_LOCKS: Dict[str, threading.Lock] = {}
+_LOCAL_TV_LOCKS_GUARD = threading.Lock()
+
+
+def _local_tv_lock(ip: str) -> threading.Lock:
+    with _LOCAL_TV_LOCKS_GUARD:
+        lock = _LOCAL_TV_LOCKS.get(ip)
+        if lock is None:
+            lock = threading.Lock()
+            _LOCAL_TV_LOCKS[ip] = lock
+        return lock
+
+
+@contextlib.contextmanager
+def _tv_exclusive(ip: str, wait: float):
+    """Hold a TV for one operation at a time, across threads and gunicorn workers."""
+    give_up_at = time.monotonic() + wait
+    busy = FrameTVUnavailableError(f"TV {ip} is busy with another request")
+
+    local = _local_tv_lock(ip)
+    if not local.acquire(timeout=max(0.0, wait)):
+        raise busy
+
+    handle = None
+    try:
+        if fcntl is not None:
+            TV_LOCK_DIR.mkdir(parents=True, exist_ok=True)
+            handle = open(TV_LOCK_DIR.joinpath(f"tv-{_safe_ip(ip)}"), "w")
+            while True:
+                try:
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if time.monotonic() >= give_up_at:
+                        raise busy
+                    time.sleep(0.1)
+        yield
+    finally:
+        if handle is not None:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+            handle.close()
+        local.release()
 
 
 class _TVSession:
@@ -248,35 +310,37 @@ def _tv_call(
             f"TV {ip} did not answer recently; skipping {action_description} it for another {cooldown:.0f}s"
         )
 
-    session = _TVSession(ip, token, DEFAULT_TIMEOUT)
+    # One operation at a time per TV: concurrent art channels corrupt each other.
+    with _tv_exclusive(ip, wait=deadline):
+        session = _TVSession(ip, token, DEFAULT_TIMEOUT)
 
-    def run():
-        if open_remote:
-            session.tv.open()
-        return action(session)
+        def run():
+            if open_remote:
+                session.tv.open()
+            return action(session)
 
-    future = _TV_EXECUTOR.submit(run)
-    try:
-        result = future.result(timeout=deadline)
-    except FutureTimeoutError as err:
-        # cancel() succeeds only while the call is still queued; otherwise close the
-        # sockets so the recv() blocking the worker thread raises and lets it go.
-        if not future.cancel():
-            session.close()
-        _mark_tv_down(ip)
-        raise FrameTVTimeoutError(
-            f"Timeout after {deadline}s while {action_description} TV {ip}"
-        ) from err
-    except Exception as err:
-        session.close()
-        if _is_connection_error(err):
+        future = _TV_EXECUTOR.submit(run)
+        try:
+            result = future.result(timeout=deadline)
+        except FutureTimeoutError as err:
+            # cancel() succeeds only while the call is still queued; otherwise close the
+            # sockets so the recv() blocking the worker thread raises and lets it go.
+            if not future.cancel():
+                session.close()
             _mark_tv_down(ip)
-            _raise_tv_connection_error(ip, action_description, err)
-        raise
+            raise FrameTVTimeoutError(
+                f"Timeout after {deadline}s while {action_description} TV {ip}"
+            ) from err
+        except Exception as err:
+            session.close()
+            if _is_connection_error(err):
+                _mark_tv_down(ip)
+                _raise_tv_connection_error(ip, action_description, err)
+            raise
 
-    _mark_tv_up(ip)
-    session.close()
-    return result
+        _mark_tv_up(ip)
+        session.close()
+        return result
 
 
 def _fetch_matte_list(art) -> Optional[Dict]:
@@ -527,6 +591,88 @@ def change_matte(ip: str, matte: str, token: Optional[str] = None) -> None:
     except Exception:  # pylint: disable=broad-except
         logger.exception("Error changing matte on TV %s", ip)
 
+def _cached_thumbnail(ip: str, content_id: str) -> Optional[bytes]:
+    cached = _cache_get((ip, content_id))
+    if cached is not None:
+        return cached
+    disk = _thumb_disk_get(ip, content_id)
+    if disk is not None:
+        _cache_set((ip, content_id), disk)
+    return disk
+
+
+def _collect_thumbnails(art, ip: str, content_ids: List[str]) -> Dict[str, bytes]:
+    """Thumbnails for `content_ids`: cache first, then whatever is left in one TV call.
+
+    Serving the cache keeps a TV that has gone quiet from blanking a gallery it has
+    already answered for once.
+    """
+    found: Dict[str, bytes] = {}
+    missing: List[str] = []
+    for cid in content_ids:
+        cached = _cached_thumbnail(ip, cid)
+        if cached is not None:
+            found[cid] = cached
+        else:
+            missing.append(cid)
+
+    if not missing:
+        return found
+
+    try:
+        thumb_map = art.get_thumbnail_list(missing)
+    except Exception:
+        logger.debug("Batch thumbnail retrieval failed for TV %s", ip, exc_info=True)
+        return found
+
+    if isinstance(thumb_map, dict):
+        for cid, data in thumb_map.items():
+            if not isinstance(data, (bytes, bytearray)):
+                continue
+            payload = bytes(data)
+            found[cid] = payload
+            _thumb_disk_set(ip, cid, payload)
+            _cache_set((ip, cid), payload)
+    return found
+
+
+def get_tv_gallery_thumbnails(
+    ip: str, content_ids: List[str], token: Optional[str] = None
+) -> Dict[str, bytes]:
+    """Fetch several thumbnails in a single round trip to the TV.
+
+    One request beats one per image: the TV only serves a single art channel, so the
+    parallel requests a gallery page used to fire were rejecting each other.
+    """
+    cached = {}
+    missing = []
+    for cid in content_ids:
+        hit = _cached_thumbnail(ip, cid)
+        if hit is not None:
+            cached[cid] = hit
+        else:
+            missing.append(cid)
+
+    if not missing:
+        return cached
+
+    try:
+        fetched = _tv_call(
+            ip,
+            "fetching thumbnails from",
+            lambda session: _collect_thumbnails(session.art(), ip, missing),
+            token=token,
+        )
+    except FrameTVError as err:
+        # Hand back whatever was cached rather than blanking a whole page because one
+        # image was missing from it. One line: the cooldown is already recorded.
+        logger.warning("Serving %d cached thumbnails for TV %s: %s", len(cached), ip, err)
+        return cached
+
+    cached.update(fetched or {})
+    return cached
+
+
 def get_tv_gallery_images(ip: str, token: Optional[str] = None) -> List[Dict]:
     """
     Fetch the list of images currently on the Frame TV.
@@ -555,32 +701,11 @@ def get_tv_gallery_images(ip: str, token: Optional[str] = None) -> List[Dict]:
                 })
                 seen_content_ids.append(content_id)
 
-        # Serve whatever the disk cache already has, so a TV that stops answering
-        # still renders the thumbnails fetched on an earlier visit.
-        missing = []
         by_content_id = {img["content_id"]: img for img in images}
-        for cid, img in by_content_id.items():
-            disk = _thumb_disk_get(ip, cid)
-            if disk:
-                img["thumbnail"] = base64.b64encode(disk).decode("ascii")
-            else:
-                missing.append(cid)
-
-        # Fetch the rest in a single batch call to avoid many serial connections
-        try:
-            if missing:
-                thumb_map = art.get_thumbnail_list(missing)
-                if isinstance(thumb_map, dict):
-                    for cid, data in thumb_map.items():
-                        img = by_content_id.get(cid)
-                        if img is None or not isinstance(data, (bytes, bytearray)):
-                            continue
-                        b = bytes(data)
-                        img["thumbnail"] = base64.b64encode(b).decode("ascii")
-                        _thumb_disk_set(ip, cid, b)
-        except Exception:
-            # Fall back silently if batch thumbnail retrieval fails
-            logger.debug("Batch thumbnail retrieval failed for TV %s", ip, exc_info=True)
+        for cid, data in _collect_thumbnails(art, ip, list(by_content_id)).items():
+            img = by_content_id.get(cid)
+            if img is not None:
+                img["thumbnail"] = base64.b64encode(data).decode("ascii")
 
         return images
 
@@ -615,40 +740,19 @@ def get_tv_gallery_thumbnail(ip: str, content_id: str, token: Optional[str] = No
     Returns:
         Optional[bytes]: Thumbnail image bytes, or None if unavailable.
     """
-    # Check in-memory cache first
-    cached = _cache_get((ip, content_id))
+    cached = _cached_thumbnail(ip, content_id)
     if cached is not None:
         return cached
 
-    # Check disk-backed cache
-    disk = _thumb_disk_get(ip, content_id)
-    if disk is not None:
-        # also populate in-memory cache
-        _cache_set((ip, content_id), disk)
-        return disk
-
     def action(session: _TVSession) -> Optional[bytes]:
         art = session.art()
-        thumbnail_bytes = None
-
-        # Newer firmware tends to be more reliable when we request thumbnails
-        # through the D2D list endpoint, which returns the response over the
-        # response socket.
-        try:
-            thumbnail_map = art.get_thumbnail_list([content_id])
-            if isinstance(thumbnail_map, dict):
-                thumbnail_bytes = next(
-                    (bytes(data) for data in thumbnail_map.values() if isinstance(data, (bytes, bytearray))),
-                    None,
-                )
-        except Exception:
-            thumbnail_bytes = None
-
+        # The D2D list endpoint is the reliable path on recent firmware; the single
+        # get_thumbnail call is only a fallback for sets that do not answer it.
+        thumbnail_bytes = _collect_thumbnails(art, ip, [content_id]).get(content_id)
         if thumbnail_bytes is None:
             thumbnail = art.get_thumbnail(content_id)
             if isinstance(thumbnail, (bytes, bytearray)):
                 thumbnail_bytes = bytes(thumbnail)
-
         return thumbnail_bytes
 
     thumbnail_bytes = _tv_call(ip, f"fetching thumbnail {content_id} from", action, token=token)

--- a/utils/frame_tv.py
+++ b/utils/frame_tv.py
@@ -1,8 +1,11 @@
 import socket
-from typing import Dict, List, Optional
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from typing import Any, Callable, Dict, List, Optional
 import base64
+import websocket
 from samsungtvws import SamsungTVWS
-from samsungtvws.helper import get_ssl_context
+from samsungtvws.exceptions import ConnectionFailure
 from const import CONNECTION_NAME
 import logging
 import os
@@ -10,15 +13,33 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, default))
+    except (TypeError, ValueError):
+        logger.warning("Invalid value for %s, falling back to %s", name, default)
+        return default
+
+
 DEFAULT_PORT = 8002
-DEFAULT_TIMEOUT = 8
+# Socket-level timeout handed to samsungtvws (covers connect and single reads).
+DEFAULT_TIMEOUT = _env_int("FRAME_TV_SOCKET_TIMEOUT", 8)
+# Wall-clock cap for a whole TV operation, see _tv_call().
+TV_CALL_DEADLINE = _env_int("FRAME_TV_CALL_DEADLINE", 20)
+# Uploads push the whole image over the websocket, so they get a longer budget.
+TV_UPLOAD_DEADLINE = _env_int("FRAME_TV_UPLOAD_DEADLINE", 120)
+# Pairing waits for someone to accept the prompt on the TV, so it needs room too.
+TV_PAIRING_TIMEOUT = _env_int("FRAME_TV_PAIRING_TIMEOUT", 45)
+# How long a TV is skipped after it failed to answer, so one dead set cannot
+# turn a page full of thumbnails into a page full of stuck requests.
+TV_DOWN_COOLDOWN = _env_int("FRAME_TV_DOWN_COOLDOWN", 30)
 # Simple in-memory cache to reduce repeated TV requests
 # Structure: { (ip, 'gallery'): (timestamp, value), (ip, content_id): (timestamp, bytes) }
 _CACHE: dict = {}
 _CACHE_TTL = 60  # seconds
 
 def _cache_get(key):
-    import time
     entry = _CACHE.get(key)
     if not entry:
         return None
@@ -32,7 +53,6 @@ def _cache_get(key):
     return value
 
 def _cache_set(key, value):
-    import time
     _CACHE[key] = (time.time(), value)
 
 
@@ -93,10 +113,177 @@ def _is_timeout_error(err: Exception) -> bool:
     )
 
 
-def _raise_tv_connection_error(ip: str, operation: str, err: Exception) -> None:
+def _is_connection_error(err: Exception) -> bool:
+    """True when the error means "the TV is not talking to us" rather than "the TV said no"."""
+    return isinstance(
+        err, (OSError, ConnectionFailure, FrameTVConnectionError, websocket.WebSocketException)
+    ) or _is_timeout_error(err)
+
+
+def _raise_tv_connection_error(ip: str, action_description: str, err: Exception) -> None:
     if _is_timeout_error(err):
-        raise FrameTVTimeoutError(f"Timeout while {operation} TV {ip}") from err
-    raise FrameTVConnectionError(f"Error while {operation} TV {ip}") from err
+        raise FrameTVTimeoutError(f"Timeout while {action_description} TV {ip}") from err
+    raise FrameTVConnectionError(f"Error while {action_description} TV {ip}") from err
+
+
+# --- Bounded TV calls ---
+#
+# samsungtvws has no overall timeout: art requests wait in a `while True` loop on
+# recv() until the TV answers the right frame. A set that accepts the socket but
+# stops answering therefore blocks the request forever — long enough for gunicorn
+# to kill the worker, respawn it, and hit the same wall on the next thumbnail.
+# Every TV call runs in a worker thread with a hard deadline, and the sockets are
+# closed from the outside on expiry, which is what makes the pending recv() fail.
+
+_TV_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_env_int("FRAME_TV_MAX_PARALLEL_CALLS", 8),
+    thread_name_prefix="frametv",
+)
+
+# The cooldown is shared between gunicorn workers through a marker file whose mtime is
+# when the TV last failed. Keeping it in memory would only teach one worker out of four,
+# so a page full of thumbnails would still stall once per worker.
+TV_DOWN_DIR = _DATA_DIR.joinpath('instance', 'tv_down')
+
+
+def _tv_down_marker(ip: str) -> Path:
+    safe = "".join(ch if ch.isalnum() or ch in "-._" else "_" for ch in ip)
+    return TV_DOWN_DIR.joinpath(f"tv-{safe}")
+
+
+def _tv_cooldown_remaining(ip: str) -> float:
+    try:
+        failed_at = _tv_down_marker(ip).stat().st_mtime
+    except OSError:
+        return 0.0
+    return max(0.0, TV_DOWN_COOLDOWN - (time.time() - failed_at))
+
+
+def _mark_tv_down(ip: str) -> None:
+    try:
+        TV_DOWN_DIR.mkdir(parents=True, exist_ok=True)
+        _tv_down_marker(ip).touch()
+    except OSError:
+        logger.debug("Could not record TV %s as unreachable", ip, exc_info=True)
+
+
+def _mark_tv_up(ip: str) -> None:
+    try:
+        _tv_down_marker(ip).unlink()
+    except OSError:
+        pass
+
+
+class _TVSession:
+    """A TV connection (remote channel + art channel) closable from another thread.
+
+    samsungtvws opens a fresh art channel on every `tv.art()` call, so the object is
+    kept here: one channel per operation instead of one per call, and a handle the
+    caller can close to unblock a read that is stuck in the worker thread.
+    """
+
+    def __init__(self, ip: str, token: Optional[str], timeout: int):
+        self.ip = ip
+        self._tv = SamsungTVWS(
+            host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME, timeout=timeout
+        )
+        self._art = None
+
+    @property
+    def tv(self) -> SamsungTVWS:
+        return self._tv
+
+    def art(self):
+        if self._art is None:
+            self._art = self._tv.art()
+        return self._art
+
+    def close(self) -> None:
+        for channel in (self._art, self._tv):
+            if channel is None:
+                continue
+            try:
+                channel.close()
+            except Exception:
+                logger.debug("Error closing channel for TV %s", self.ip, exc_info=True)
+
+
+def _tv_call(
+    ip: str,
+    action_description: str,
+    action: Callable[["_TVSession"], Any],
+    *,
+    token: Optional[str] = None,
+    deadline: Optional[int] = None,
+    open_remote: bool = True,
+) -> Any:
+    """Run `action(session)` against the TV, never blocking longer than `deadline`.
+
+    Raises FrameTVTimeoutError when the deadline expires and FrameTVConnectionError
+    when the TV is unreachable; errors coming from the TV itself (a rejected
+    request, a bad content id) are re-raised untouched so callers can tell the two
+    apart. A TV that fails is skipped for TV_DOWN_COOLDOWN seconds.
+    """
+    if deadline is None:
+        deadline = TV_CALL_DEADLINE
+
+    cooldown = _tv_cooldown_remaining(ip)
+    if cooldown > 0:
+        raise FrameTVConnectionError(
+            f"TV {ip} did not answer recently; skipping {action_description} it for another {cooldown:.0f}s"
+        )
+
+    session = _TVSession(ip, token, DEFAULT_TIMEOUT)
+
+    def run():
+        if open_remote:
+            session.tv.open()
+        return action(session)
+
+    future = _TV_EXECUTOR.submit(run)
+    try:
+        result = future.result(timeout=deadline)
+    except FutureTimeoutError as err:
+        # cancel() succeeds only while the call is still queued; otherwise close the
+        # sockets so the recv() blocking the worker thread raises and lets it go.
+        if not future.cancel():
+            session.close()
+        _mark_tv_down(ip)
+        raise FrameTVTimeoutError(
+            f"Timeout after {deadline}s while {action_description} TV {ip}"
+        ) from err
+    except Exception as err:
+        session.close()
+        if _is_connection_error(err):
+            _mark_tv_down(ip)
+            _raise_tv_connection_error(ip, action_description, err)
+        raise
+
+    _mark_tv_up(ip)
+    session.close()
+    return result
+
+
+def _fetch_matte_list(art) -> Optional[Dict]:
+    try:
+        return art.get_matte_list()
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Error getting matte list")
+        return None
+
+
+def _matte_kwargs(art, matte: Optional[str]) -> Dict[str, str]:
+    if matte is None:
+        return {}
+    available_mattes = _fetch_matte_list(art)
+    if available_mattes and 'matte_types' in available_mattes:
+        matte_types = available_mattes['matte_types']
+        # Extract matte_type values from the list of dicts
+        available_matte_names = [m.get('matte_type') for m in matte_types if isinstance(m, dict)]
+        if matte not in available_matte_names:
+            logger.warning("Requested matte '%s' not in available mattes: %s", matte, available_matte_names)
+    return {'matte': matte, 'portrait_matte': matte}
+
 
 def upload_artwork(
     ip: str,
@@ -115,52 +302,43 @@ def upload_artwork(
         art_path (str): Path to the artwork image file.
         brightness (Optional[int]): Brightness level to set after upload.
         display (bool): Whether to display the uploaded image immediately.
-        delete_others (bool): Whether to delete other artworks (not implemented).
+        delete_others (bool): Whether to delete every other artwork on the TV.
         token (Optional[str]): Token string to use for authentication.
         matte (Optional[str]): Matte/frame style to use (e.g., 'shadowbox_polar', 'shadowbox_modern', 'none' (no matte)).
     Returns:
         Optional[str]: Content ID of the uploaded image, or None if failed.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    upload_kwargs = {}
-    available_mattes = get_available_mattes(ip, token)
-    if matte is not None:
-        # Validate matte against available options
-        if available_mattes and 'matte_types' in available_mattes:
-            matte_types = available_mattes['matte_types']
-            # Extract matte_type values from the list of dicts
-            available_matte_names = [m.get('matte_type') for m in matte_types if isinstance(m, dict)]
-            if matte not in available_matte_names:
-                logger.warning("Requested matte '%s' not in available mattes: %s", matte, available_matte_names)
-        upload_kwargs['matte'] = matte
-        upload_kwargs['portrait_matte'] = matte
     with open(art_path, "rb") as f:
-        content_id = tv.art().upload(f.read(), **upload_kwargs)
-    if brightness is not None:
-        tv.art().set_brightness(brightness)
-    if display and content_id:
-        tv.art().select_image(content_id, show=True)
-    tv.close()
+        payload = f.read()
 
-    if delete_others:
-        _delete_other_images(tv.art(), content_id, debug=True)
+    def action(session: _TVSession) -> Optional[str]:
+        art = session.art()
+        content_id = art.upload(payload, **_matte_kwargs(art, matte))
+        if brightness is not None:
+            art.set_brightness(brightness)
+        if display and content_id:
+            art.select_image(content_id, show=True)
+        if delete_others:
+            _delete_other_images(art, content_id, debug=True)
+        return content_id
 
-    return content_id
+    return _tv_call(ip, "uploading artwork to", action, token=token, deadline=TV_UPLOAD_DEADLINE)
 
 def _delete_other_images(art, keep_content_id: str, *, debug: bool) -> None:
+    available = []
     try:
         # art.available() returns a content list
         available = art.available() or []
     except Exception as err:  # pylint: disable=broad-except
         logger.exception("Could not enumerate TV gallery")
+        return
 
     deletions = [item.get("content_id") for item in available if item.get("content_id") and item.get("content_id") != keep_content_id]
-    
+
     kept = [item.get("content_id") for item in available if item.get("content_id") == keep_content_id]
     if len(kept) > 1:
         logger.warning("Found %d copies of active image %s; keeping all to avoid accidental deletion.", len(kept), keep_content_id)
-    
+
     if not deletions:
         logger.debug("No other images to delete")
         return
@@ -176,20 +354,17 @@ def delete_all_images_from_tv(ip: str, token: Optional[str] = None) -> None:
         ip (str): IP address of the TV.
         token (Optional[str]): Token string to use for authentication.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    try:
-        available = tv.art().available() or []
+    def action(session: _TVSession) -> None:
+        art = session.art()
+        available = art.available() or []
         content_ids = [item.get("content_id") for item in available if item.get("content_id")]
         if content_ids:
-            tv.art().delete_list(content_ids)
+            art.delete_list(content_ids)
             logger.info("Deleted %d images from TV %s", len(content_ids), ip)
         else:
             logger.info("No images found on TV %s to delete", ip)
-    except Exception as err:  # pylint: disable=broad-except
-        logger.exception("Error while deleting images from TV %s", ip)
-    finally:
-        tv.close()
+
+    _tv_call(ip, "deleting images from", action, token=token)
 
 def play_uploaded_content(ip: str, content_id: str, token: Optional[str] = None) -> None:
     """
@@ -199,10 +374,12 @@ def play_uploaded_content(ip: str, content_id: str, token: Optional[str] = None)
         content_id (str): Content ID of the uploaded image.
         token (Optional[str]): Token string to use for authentication.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    tv.art().select_image(content_id, show=True)
-    tv.close()
+    _tv_call(
+        ip,
+        f"playing image {content_id} on",
+        lambda session: session.art().select_image(content_id, show=True),
+        token=token,
+    )
 
 def set_brightness(ip: str, brightness: int, token: Optional[str] = None) -> None:
     """
@@ -212,10 +389,12 @@ def set_brightness(ip: str, brightness: int, token: Optional[str] = None) -> Non
         brightness (int): Brightness level to set.
         token (Optional[str]): Token string to use for authentication.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    tv.art().set_brightness(brightness)
-    tv.close()
+    _tv_call(
+        ip,
+        "setting brightness on",
+        lambda session: session.art().set_brightness(brightness),
+        token=token,
+    )
 
 def is_art_mode_on(ip: str, token: Optional[str] = None) -> bool:
     """
@@ -226,10 +405,12 @@ def is_art_mode_on(ip: str, token: Optional[str] = None) -> bool:
     Returns:
         bool: True if art mode is enabled, False otherwise.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    status = tv.art().get_artmode()
-    tv.close()
+    status = _tv_call(
+        ip,
+        "reading art mode from",
+        lambda session: session.art().get_artmode(),
+        token=token,
+    )
     return status == "on"
 
 def is_tv_reachable(ip: str, token: Optional[str] = None) -> bool:
@@ -242,9 +423,7 @@ def is_tv_reachable(ip: str, token: Optional[str] = None) -> bool:
         bool: True if the TV is reachable, False otherwise.
     """
     try:
-        tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-        tv.open()
-        tv.close()
+        _tv_call(ip, "reaching", lambda session: True, token=token)
         return True
     except Exception:
         return False
@@ -267,10 +446,7 @@ def power_off(ip: str, token: Optional[str] = None) -> None:
         ip (str): IP address of the TV.
         token (Optional[str]): Token string to use for authentication.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    tv.send_key("KEY_POWER")
-    tv.close()
+    _tv_call(ip, "powering off", lambda session: session.tv.send_key("KEY_POWER"), token=token)
 
 def enable_art_mode(ip: str, token: Optional[str] = None) -> None:
     """
@@ -279,10 +455,12 @@ def enable_art_mode(ip: str, token: Optional[str] = None) -> None:
         ip (str): IP address of the TV.
         token (Optional[str]): Token string to use for authentication.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-    tv.open()
-    tv.art().set_artmode(True)
-    tv.close()
+    _tv_call(
+        ip,
+        "enabling art mode on",
+        lambda session: session.art().set_artmode(True),
+        token=token,
+    )
 
 def remove_token(ip: str) -> None:
     """
@@ -302,12 +480,13 @@ def get_available_mattes(ip: str, token: Optional[str] = None) -> Optional[Dict]
         Optional[Dict]: Dictionary with 'matte_types' and 'matte_colors' keys, or None if failed.
     """
     try:
-        tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-        tv.open()
-        mattes = tv.art().get_matte_list()
-        tv.close()
-        return mattes
-    except Exception as err:  # pylint: disable=broad-except
+        return _tv_call(
+            ip,
+            "getting matte list from",
+            lambda session: _fetch_matte_list(session.art()),
+            token=token,
+        )
+    except Exception:  # pylint: disable=broad-except
         logger.exception("Error getting matte list from TV %s", ip)
         return None
 
@@ -320,11 +499,13 @@ def change_matte(ip: str, matte: str, token: Optional[str] = None) -> None:
         token (Optional[str]): Token string to use for authentication.
     """
     try:
-        tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME)
-        tv.open()
-        tv.art().change_matte(matte)
-        tv.close()
-    except Exception as err:  # pylint: disable=broad-except
+        _tv_call(
+            ip,
+            "changing matte on",
+            lambda session: session.art().change_matte(matte),
+            token=token,
+        )
+    except Exception:  # pylint: disable=broad-except
         logger.exception("Error changing matte on TV %s", ip)
 
 def get_tv_gallery_images(ip: str, token: Optional[str] = None) -> List[Dict]:
@@ -338,10 +519,8 @@ def get_tv_gallery_images(ip: str, token: Optional[str] = None) -> List[Dict]:
     """
     # Do not cache the gallery listing to ensure deletions/changes are observed live
 
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME, timeout=DEFAULT_TIMEOUT)
-    try:
-        tv.open()
-        art = tv.art()
+    def action(session: _TVSession) -> List[Dict]:
+        art = session.art()
         available = art.available() or []
 
         images = []
@@ -357,39 +536,36 @@ def get_tv_gallery_images(ip: str, token: Optional[str] = None) -> List[Dict]:
                 })
                 seen_content_ids.append(content_id)
 
-        # Try to fetch thumbnails in a single batch call to avoid many serial connections
+        # Serve whatever the disk cache already has, so a TV that stops answering
+        # still renders the thumbnails fetched on an earlier visit.
+        missing = []
+        by_content_id = {img["content_id"]: img for img in images}
+        for cid, img in by_content_id.items():
+            disk = _thumb_disk_get(ip, cid)
+            if disk:
+                img["thumbnail"] = base64.b64encode(disk).decode("ascii")
+            else:
+                missing.append(cid)
+
+        # Fetch the rest in a single batch call to avoid many serial connections
         try:
-            if seen_content_ids:
-                thumb_map = art.get_thumbnail_list(seen_content_ids)
+            if missing:
+                thumb_map = art.get_thumbnail_list(missing)
                 if isinstance(thumb_map, dict):
-                    for img in images:
-                        cid = img["content_id"]
-                        # Prefer disk cache first
-                        disk = _thumb_disk_get(ip, cid)
-                        if disk:
-                            img["thumbnail"] = base64.b64encode(disk).decode("ascii")
+                    for cid, data in thumb_map.items():
+                        img = by_content_id.get(cid)
+                        if img is None or not isinstance(data, (bytes, bytearray)):
                             continue
-                        data = thumb_map.get(cid)
-                        if isinstance(data, (bytes, bytearray)):
-                            b = bytes(data)
-                            img["thumbnail"] = base64.b64encode(b).decode("ascii")
-                            # persist to disk
-                            try:
-                                _thumb_disk_set(ip, cid, b)
-                            except Exception:
-                                pass
+                        b = bytes(data)
+                        img["thumbnail"] = base64.b64encode(b).decode("ascii")
+                        _thumb_disk_set(ip, cid, b)
         except Exception:
             # Fall back silently if batch thumbnail retrieval fails
-            pass
+            logger.debug("Batch thumbnail retrieval failed for TV %s", ip, exc_info=True)
 
         return images
-    except Exception as err:  # pylint: disable=broad-except
-        _raise_tv_connection_error(ip, "fetching gallery images from", err)
-    finally:
-        try:
-            tv.close()
-        except Exception:
-            pass
+
+    return _tv_call(ip, "fetching gallery images from", action, token=token)
 
 def delete_tv_image(ip: str, content_id: str, token: Optional[str] = None) -> bool:
     """
@@ -400,21 +576,14 @@ def delete_tv_image(ip: str, content_id: str, token: Optional[str] = None) -> bo
         token (Optional[str]): Token string to use for authentication.
     Returns:
         bool: True if deletion was successful.
-    Raises:
-        RuntimeError: If the TV connection or deletion fails.
     """
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME, timeout=DEFAULT_TIMEOUT)
-    try:
-        tv.open()
-        tv.art().delete(content_id)
-        return True
-    except Exception as err:  # pylint: disable=broad-except
-        _raise_tv_connection_error(ip, f"deleting image {content_id} from", err)
-    finally:
-        try:
-            tv.close()
-        except Exception:
-            pass
+    _tv_call(
+        ip,
+        f"deleting image {content_id} from",
+        lambda session: session.art().delete(content_id),
+        token=token,
+    )
+    return True
 
 def get_tv_gallery_thumbnail(ip: str, content_id: str, token: Optional[str] = None) -> Optional[bytes]:
     """
@@ -438,11 +607,8 @@ def get_tv_gallery_thumbnail(ip: str, content_id: str, token: Optional[str] = No
         _cache_set((ip, content_id), disk)
         return disk
 
-    tv = SamsungTVWS(host=ip, port=DEFAULT_PORT, token=token, name=CONNECTION_NAME, timeout=DEFAULT_TIMEOUT)
-    try:
-        tv.open()
-        art = tv.art()
-
+    def action(session: _TVSession) -> Optional[bytes]:
+        art = session.art()
         thumbnail_bytes = None
 
         # Newer firmware tends to be more reliable when we request thumbnails
@@ -463,18 +629,10 @@ def get_tv_gallery_thumbnail(ip: str, content_id: str, token: Optional[str] = No
             if isinstance(thumbnail, (bytes, bytearray)):
                 thumbnail_bytes = bytes(thumbnail)
 
-        if thumbnail_bytes is not None:
-            try:
-                _thumb_disk_set(ip, content_id, thumbnail_bytes)
-            except Exception:
-                pass
-            _cache_set((ip, content_id), thumbnail_bytes)
-            return thumbnail_bytes
-        return None
-    except Exception as err:  # pylint: disable=broad-except
-        _raise_tv_connection_error(ip, f"fetching thumbnail {content_id} from", err)
-    finally:
-        try:
-            tv.close()
-        except Exception:
-            pass
+        return thumbnail_bytes
+
+    thumbnail_bytes = _tv_call(ip, f"fetching thumbnail {content_id} from", action, token=token)
+    if thumbnail_bytes is not None:
+        _thumb_disk_set(ip, content_id, thumbnail_bytes)
+        _cache_set((ip, content_id), thumbnail_bytes)
+    return thumbnail_bytes

--- a/utils/frame_tv.py
+++ b/utils/frame_tv.py
@@ -99,6 +99,15 @@ class FrameTVTimeoutError(FrameTVConnectionError):
     """Exception for timeouts while talking to the Frame TV."""
     pass
 
+
+class FrameTVUnavailableError(FrameTVConnectionError):
+    """Raised instead of contacting a TV that just failed, while its cooldown lasts.
+
+    This is the circuit breaker doing its job, not an incident: callers should report
+    it without a stack trace, since one page of thumbnails raises it many times over.
+    """
+    pass
+
 class FrameTVUploadError(FrameTVError):
     """Exception for upload errors to the Frame TV."""
     pass
@@ -216,6 +225,7 @@ def _tv_call(
     token: Optional[str] = None,
     deadline: Optional[int] = None,
     open_remote: bool = True,
+    skip_when_down: bool = True,
 ) -> Any:
     """Run `action(session)` against the TV, never blocking longer than `deadline`.
 
@@ -223,13 +233,18 @@ def _tv_call(
     when the TV is unreachable; errors coming from the TV itself (a rejected
     request, a bad content id) are re-raised untouched so callers can tell the two
     apart. A TV that fails is skipped for TV_DOWN_COOLDOWN seconds.
+
+    `skip_when_down` is what the cooldown protects against: bursts of background
+    reads, above all the one request per thumbnail a gallery page fires. Deliberate
+    actions pass False — someone pressing play is waiting for that TV specifically,
+    and would rather wait for a real answer than be told to come back later.
     """
     if deadline is None:
         deadline = TV_CALL_DEADLINE
 
-    cooldown = _tv_cooldown_remaining(ip)
+    cooldown = _tv_cooldown_remaining(ip) if skip_when_down else 0
     if cooldown > 0:
-        raise FrameTVConnectionError(
+        raise FrameTVUnavailableError(
             f"TV {ip} did not answer recently; skipping {action_description} it for another {cooldown:.0f}s"
         )
 
@@ -322,7 +337,7 @@ def upload_artwork(
             _delete_other_images(art, content_id, debug=True)
         return content_id
 
-    return _tv_call(ip, "uploading artwork to", action, token=token, deadline=TV_UPLOAD_DEADLINE)
+    return _tv_call(ip, "uploading artwork to", action, token=token, deadline=TV_UPLOAD_DEADLINE, skip_when_down=False)
 
 def _delete_other_images(art, keep_content_id: str, *, debug: bool) -> None:
     available = []
@@ -364,7 +379,7 @@ def delete_all_images_from_tv(ip: str, token: Optional[str] = None) -> None:
         else:
             logger.info("No images found on TV %s to delete", ip)
 
-    _tv_call(ip, "deleting images from", action, token=token)
+    _tv_call(ip, "deleting images from", action, token=token, skip_when_down=False)
 
 def play_uploaded_content(ip: str, content_id: str, token: Optional[str] = None) -> None:
     """
@@ -379,6 +394,7 @@ def play_uploaded_content(ip: str, content_id: str, token: Optional[str] = None)
         f"playing image {content_id} on",
         lambda session: session.art().select_image(content_id, show=True),
         token=token,
+        skip_when_down=False,
     )
 
 def set_brightness(ip: str, brightness: int, token: Optional[str] = None) -> None:
@@ -394,6 +410,7 @@ def set_brightness(ip: str, brightness: int, token: Optional[str] = None) -> Non
         "setting brightness on",
         lambda session: session.art().set_brightness(brightness),
         token=token,
+        skip_when_down=False,
     )
 
 def is_art_mode_on(ip: str, token: Optional[str] = None) -> bool:
@@ -446,7 +463,7 @@ def power_off(ip: str, token: Optional[str] = None) -> None:
         ip (str): IP address of the TV.
         token (Optional[str]): Token string to use for authentication.
     """
-    _tv_call(ip, "powering off", lambda session: session.tv.send_key("KEY_POWER"), token=token)
+    _tv_call(ip, "powering off", lambda session: session.tv.send_key("KEY_POWER"), token=token, skip_when_down=False)
 
 def enable_art_mode(ip: str, token: Optional[str] = None) -> None:
     """
@@ -460,6 +477,7 @@ def enable_art_mode(ip: str, token: Optional[str] = None) -> None:
         "enabling art mode on",
         lambda session: session.art().set_artmode(True),
         token=token,
+        skip_when_down=False,
     )
 
 def remove_token(ip: str) -> None:
@@ -504,6 +522,7 @@ def change_matte(ip: str, matte: str, token: Optional[str] = None) -> None:
             "changing matte on",
             lambda session: session.art().change_matte(matte),
             token=token,
+            skip_when_down=False,
         )
     except Exception:  # pylint: disable=broad-except
         logger.exception("Error changing matte on TV %s", ip)
@@ -582,6 +601,7 @@ def delete_tv_image(ip: str, content_id: str, token: Optional[str] = None) -> bo
         f"deleting image {content_id} from",
         lambda session: session.art().delete(content_id),
         token=token,
+        skip_when_down=False,
     )
     return True
 


### PR DESCRIPTION
First half of the split you asked for in #61 (the other is the albums and UI work). This
one stands alone and is the part worth landing first.

## One unresponsive TV took the whole app down

Opening a TV gallery for a set that had stopped answering froze the server until gunicorn
killed the worker, respawned it, and hit the same wall on the next thumbnail:

```
[CRITICAL] WORKER TIMEOUT (pid:8)
[ERROR] Error handling request GET /api/tv/10.0.0.13/gallery/SAM-F10004985/thumbnail
  File ".../samsungtvws/art/art.py", line 188, in _wait_for_d2d
```

Repeating every 30 seconds. Navigation and adding a TV appeared dead throughout, which
reads as the app rebooting in a loop.

**Why the existing timeout does not catch it.** `SamsungTVWS(timeout=…)` bounds a single
socket read, but `SamsungTVArt._wait_for_d2d` sits in a `while True` around `recv()` until
the TV sends the frame it wants. A TV that accepts the socket and then goes quiet is never
bounded. The deadline has to live outside the library.

Every TV call now runs in a worker thread with a wall-clock deadline, and the sockets are
closed from the outside when it expires, which is what releases the parked read. A TV that
fails is skipped for a cooldown, recorded in a marker file so all gunicorn workers share it
instead of each learning the hard way.

## A Frame TV serves one art channel

This was the second, independent cause, and the one that actually broke thumbnails:

```
samsungtvws/connection.py, in open
    raise exceptions.ConnectionFailure(response)
ConnectionFailure: {... 'event': 'ms.channel.clientConnect'}
```

`ms.channel.clientConnect` is the TV announcing that another client just joined the
channel. `open()` accepts only `ms.channel.connect`, so two connections opened at once do
not queue — they reject each other. The three failures in the report share a millisecond,
which is what gave it away.

The gallery page was the source: one request per missing thumbnail, six in flight. Those
are fetched in a single round trip now, through `POST /api/tv/<ip>/gallery/thumbnails`,
which reuses the batch call the gallery listing already made. A page of fifty images opens
one connection instead of fifty. Every TV call also takes a per-TV lock, held across
workers through a lock file, so anything else touching that set waits its turn.

## Around that

- gunicorn runs several workers and an explicit timeout, so one slow TV cannot starve the
  rest of the app. Both are tunable, as are the deadlines — see the new Configuration
  table in the README.
- Adding a TV passes a timeout too; it used to block on the TCP connect until the OS gave
  up, well past the worker timeout.
- The cooldown only holds back background reads. Playing, deleting, uploading and powering
  off still go through, since someone is waiting on that specific set.
- Refusals log one line rather than a stack trace each; a page of thumbnails used to
  produce dozens for what is the breaker working as designed. A batch that cannot reach
  the TV returns the thumbnails it does have rather than failing whole.
- `upload_artwork` opened four art channels instead of one, and `_delete_other_images`
  raised `NameError` when it could not list the gallery.

## Things that were broken before this branch

- **`npm ci` fails on main.** The lockfile pins `@tailwindcss/vite` 4.1.18, whose peer
  range stops at vite 7, while dependabot moved vite to `^8`. The declared range `^4.1.13`
  already allows 4.3.3, which accepts vite 8, so refreshing the lockfile is enough —
  `package.json` is untouched.
- **`entrypoint.sh` gets CRLF on a Windows checkout**, so the image built there dies with
  `exec /entrypoint.sh: no such file or directory`. A `.gitattributes` pins shell scripts
  to LF.
- **Neither was caught because `build_image.yaml` only runs on release.** A CI workflow now
  runs the tests and the frontend build on every push and pull request, and
  `build_image.yaml` gained a `workflow_dispatch` trigger so an image can be published
  without merging a release PR first.

## Testing

Ten tests cover the deadline, the cooldown (including that it is shared across processes
and that deliberate actions bypass it) and the per-TV serialisation. Checked against a real
container: an unreachable TV gives up in 8s, the next request is refused in 0.2s, the rest
of the app answers in under a second during a burst of 40 thumbnail requests, and no worker
is killed. The upgrade path was checked by writing data with the published image, swapping
in one built from this branch on the same volume, and swapping back — no migration is
added and nothing is lost in either direction.

The albums PR carries the same infrastructure commit (lockfile, `.gitattributes`, CI) so it
is green on its own; whichever lands second sees it as a no-op.
