### PR TITLE
feat: Album selection, bulk actions (#59) and a dark mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -324,23 +324,27 @@ def api_create_album():
 
 @app.route('/api/albums/<album_name>/add', methods=['POST'])
 def api_add_image_to_album(album_name):
-    data = request.get_json()
-    image_filename = data.get('image')
-    if not image_filename:
+    """Assign one image ({"image": name}) or several ({"images": [...]}) to an album."""
+    data = request.get_json(silent=True) or {}
+    filenames = data.get('images')
+    if filenames is None:
+        single = data.get('image')
+        filenames = [single] if single else []
+    if not isinstance(filenames, list) or not all(isinstance(name, str) and name for name in filenames):
+        return {'error': 'Invalid image list'}, 400
+    if not filenames:
         return {'error': 'Image required'}, 400
+
     album = Album.query.filter_by(name=album_name).first()
     if not album:
         return {'error': 'Album not found'}, 404
 
-    existing_image = Image.query.filter_by(filename=image_filename).first()
-    if existing_image and existing_image.album_id == album.id:
-        return api_list_albums()
-
-    if existing_image:
-        existing_image.album = album
-    else:
-        existing_image = Image(filename=image_filename, album=album)
-        db.session.add(existing_image)
+    for image_filename in filenames:
+        existing_image = Image.query.filter_by(filename=image_filename).first()
+        if existing_image:
+            existing_image.album = album
+        else:
+            db.session.add(Image(filename=image_filename, album=album))
 
     db.session.commit()
     return api_list_albums()
@@ -388,25 +392,41 @@ def api_delete_album(album_name):
 
 @app.route('/api/upload', methods=['POST'])
 def upload():
-    """ Upload image to the gallery """
+    """Upload an image to the gallery, optionally straight into an album."""
     if 'file' not in request.files:
         return {'error': 'No file part'}, 400
     file = request.files['file']
     if file.filename == '':
         return {'error': 'No selected file'}, 400
-    if file and allowed_file(file.filename):
-        try:
-            filename, file_path = _normalized_upload_path(file.filename)
-        except ValueError as e:
-            return {'error': str(e)}, 400
-        file.save(file_path)
-        # Track image in DB
-        img = Image(filename=filename, album_id=None)
-        db.session.add(img)
-        db.session.commit()
-        return {'success': True, 'filename': filename}
-    else:
+    if not file or not allowed_file(file.filename):
         return {'error': 'Invalid file type'}, 400
+
+    album_id = request.form.get('album_id')
+    album = None
+    if album_id:
+        try:
+            album = Album.query.get(int(album_id))
+        except (TypeError, ValueError):
+            return {'error': 'Invalid album'}, 400
+        if not album:
+            return {'error': 'Album not found'}, 404
+
+    try:
+        filename, file_path = _normalized_upload_path(file.filename)
+    except ValueError as e:
+        return {'error': str(e)}, 400
+    file.save(file_path)
+
+    # Re-uploading the same filename overwrites the file, so reuse its row instead of
+    # leaving a second one behind pointing at the same image.
+    img = Image.query.filter_by(filename=filename).first()
+    if not img:
+        img = Image(filename=filename)
+        db.session.add(img)
+    if album:
+        img.album = album
+    db.session.commit()
+    return {'success': True, 'filename': filename, 'album_id': album.id if album else None}
     
 # --- Play Uploaded Image on TV ---
 @app.route('/api/tv/play_uploaded', methods=['POST'])

--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -2,7 +2,9 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
-@custom-variant dark (&:is(.dark *));
+/* Matches the element carrying the class as well as its descendants: next-themes puts
+   .dark on <html>, so `dark:` has to apply to <html> itself too. */
+@custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
@@ -11,11 +13,17 @@
 
 html,
 body {
-  @apply bg-white dark:bg-gray-950;
+  @apply bg-background text-foreground;
+}
 
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
+/* Drives the native widgets (scrollbars, selects, checkboxes) off the chosen theme
+   rather than off the OS preference, which the toggle is allowed to override. */
+:root {
+  color-scheme: light;
+}
+
+.dark {
+  color-scheme: dark;
 }
 
 @theme inline {

--- a/frontend/app/components/AlbumCard.tsx
+++ b/frontend/app/components/AlbumCard.tsx
@@ -35,12 +35,12 @@ export default function AlbumCard({
   }
 
   return (
-    <div className="border rounded-xl p-3 cursor-pointer hover:border-gray-300 transition flex justify-between items-center" onClick={() => handleOpenAlbum(album)}>
+    <div className="border rounded-xl p-3 cursor-pointer hover:border-border transition flex justify-between items-center" onClick={() => handleOpenAlbum(album)}>
       <div className="font-bold mb-2 flex flex-col">
         <span>{album.name}</span>
 
         <div className="flex flex-wrap gap-2 mt-3">
-          {album.images.length === 0 && <span className="text-gray-400">No images</span>}
+          {album.images.length === 0 && <span className="text-muted-foreground">No images</span>}
           {Array.isArray(album.images) && album.images.map(img => (
             <img
               key={img}

--- a/frontend/app/components/CropImageModal.tsx
+++ b/frontend/app/components/CropImageModal.tsx
@@ -131,10 +131,10 @@ const CropImageModal: React.FC<CropImageModalProps> = ({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-      <div className="w-full max-w-4xl rounded-lg bg-white shadow-lg overflow-hidden">
+      <div className="w-full max-w-4xl rounded-lg bg-card shadow-lg overflow-hidden">
         <div className="flex items-center justify-between border-b px-4 py-3">
           <h3 className="text-lg font-semibold">Crop Image: {filename}</h3>
-          <button onClick={handleClose} className="text-gray-700 hover:text-black">
+          <button onClick={handleClose} className="text-foreground hover:text-black">
             <XMarkIcon className="h-5 w-5" />
           </button>
         </div>
@@ -193,7 +193,7 @@ const CropImageModal: React.FC<CropImageModalProps> = ({
                 {cropActionLoading ? 'Cropping…' : cropperReady ? 'Apply Crop' : 'Loading...'}
               </button>
               <button
-                className="flex-1 bg-gray-200 text-gray-800 rounded px-4 py-2 hover:bg-gray-300"
+                className="flex-1 bg-gray-200 text-foreground rounded px-4 py-2 hover:bg-gray-300"
                 onClick={() => {
                   if (cropperRef.current?.cropper) {
                     cropperRef.current.cropper.reset();

--- a/frontend/app/components/CropImageModal.tsx
+++ b/frontend/app/components/CropImageModal.tsx
@@ -193,7 +193,7 @@ const CropImageModal: React.FC<CropImageModalProps> = ({
                 {cropActionLoading ? 'Cropping…' : cropperReady ? 'Apply Crop' : 'Loading...'}
               </button>
               <button
-                className="flex-1 bg-gray-200 text-foreground rounded px-4 py-2 hover:bg-gray-300"
+                className="flex-1 bg-secondary text-secondary-foreground rounded px-4 py-2 hover:bg-secondary/80"
                 onClick={() => {
                   if (cropperRef.current?.cropper) {
                     cropperRef.current.cropper.reset();

--- a/frontend/app/components/TVGalleryImageCard.tsx
+++ b/frontend/app/components/TVGalleryImageCard.tsx
@@ -27,12 +27,12 @@ export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoad
   return (
     <div
       key={image.content_id}
-      className="flex gap-4 p-4 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md transition-shadow"
+      className="flex gap-4 p-4 bg-card border border-border rounded-lg hover:shadow-md transition-shadow"
     >
       {/* The thumbnail always comes from the parent's single batched request. Letting the
           <img> fall back to the per-image endpoint fired one TV websocket per card, which
           is what used to pile up and starve the server when a TV stopped answering. */}
-      <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
+      <div className="relative h-20 w-20 shrink-0 overflow-hidden rounded-xl bg-muted border border-border">
         {image.thumbnail ? (
           <>
             {!imgLoaded && !imgError && <Loader />}
@@ -45,7 +45,7 @@ export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoad
               onError={() => setImgError(true)}
             />
             {imgError && (
-              <div className="absolute inset-0 flex items-center justify-center text-gray-400">
+              <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
                 <PhotoIcon className="h-8 w-8" />
               </div>
             )}
@@ -53,7 +53,7 @@ export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoad
         ) : thumbnailsLoading ? (
           <Loader />
         ) : (
-          <div className="absolute inset-0 flex items-center justify-center text-gray-400" title="No preview available">
+          <div className="absolute inset-0 flex items-center justify-center text-muted-foreground" title="No preview available">
             <PhotoIcon className="h-8 w-8" />
           </div>
         )}
@@ -61,9 +61,9 @@ export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoad
 
       <div className="flex-1 min-w-0 self-center">
         <p className="font-medium truncate">{image.filename}</p>
-        <div className="text-xs text-gray-500 mt-1 space-y-1">
+        <div className="text-xs text-muted-foreground mt-1 space-y-1">
           <p>Added: {formatDate(image.date_added)}</p>
-          <p className="text-gray-400 truncate">ID: {image.content_id}</p>
+          <p className="text-muted-foreground truncate">ID: {image.content_id}</p>
         </div>
       </div>
       <div className="flex gap-2 self-center ml-4">

--- a/frontend/app/components/bottomTabs.tsx
+++ b/frontend/app/components/bottomTabs.tsx
@@ -36,7 +36,11 @@ export default function BottomTabs() {
           }
           .bottom-tab-active {
             transform: scale(1.3);
-            color: #2563eb; /* Tailwind blue-600 */;
+            color: #2563eb; /* blue-600 */
+          }
+          /* blue-600 only reaches 3.5:1 on the dark surface, so lift it to blue-400. */
+          :where(.dark) .bottom-tab-active {
+            color: #60a5fa;
           }
         `}</style>
 

--- a/frontend/app/components/bottomTabs.tsx
+++ b/frontend/app/components/bottomTabs.tsx
@@ -26,7 +26,7 @@ export default function BottomTabs() {
 
   return (
     <div className={`fixed z-50 w-full max-w-lg -translate-x-1/2 ${isIOS ? 'bottom-0' : 'bottom-4'} left-1/2`} >
-      <div className="grid h-16 grid-cols-4 mx-auto bg-white dark:bg-gray-950 border border-gray-200 dark:border-gray-700 rounded-full">
+      <div className="grid h-16 grid-cols-4 mx-auto bg-card border border-border rounded-full">
         <style>{`
           .bottom-tab-icon {
             transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), color 0.2s;

--- a/frontend/app/components/header.tsx
+++ b/frontend/app/components/header.tsx
@@ -1,6 +1,8 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 import { useLocation } from "react-router";
+import { useTheme } from "next-themes";
+import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
 
 const VERSION = import.meta.env.VITE_APP_VERSION || "dev";
 
@@ -10,6 +12,30 @@ const pageNames: { [key: string]: string } = {
   "/settings": "Settings"
 };
 
+function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  // The theme is only known once mounted; render a placeholder until then so the
+  // button does not flash the wrong icon.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <button
+      type="button"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      className="rounded-full p-2 text-gray-200 hover:bg-gray-700 hover:text-white transition-colors"
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      aria-label="Switch between light and dark mode"
+    >
+      {mounted
+        ? (isDark ? <SunIcon className="h-5 w-5" /> : <MoonIcon className="h-5 w-5" />)
+        : <span className="block h-5 w-5" />}
+    </button>
+  );
+}
+
 export default function Header() {
   const location = useLocation();
   const pageName = pageNames[location.pathname] || "Page";
@@ -18,9 +44,13 @@ export default function Header() {
       <div className="flex items-center justify-between px-6 py-3">
         <div className="flex items-baseline gap-2">
           <h1 className="text-xl font-bold">FrameTV Art Gallery</h1>
+          {/* The bar stays dark in both themes, so its text keeps fixed colours. */}
           <span className="text-xs text-gray-400 font-medium">{VERSION}</span>
         </div>
-        <span className="text-base font-semibold text-gray-200">{pageName}</span>
+        <div className="flex items-center gap-3">
+          <span className="text-base font-semibold text-gray-200">{pageName}</span>
+          <ThemeToggle />
+        </div>
       </div>
     </header>
   );

--- a/frontend/app/components/imageCard.tsx
+++ b/frontend/app/components/imageCard.tsx
@@ -176,14 +176,14 @@ const ImageCard: React.FC<ImageCardProps> = ({
     <>
       <div
         className={
-          `group relative flex flex-col overflow-hidden rounded-lg bg-white shadow-sm transition-shadow duration-200 hover:shadow-lg ` +
+          `group relative flex flex-col overflow-hidden rounded-lg bg-card shadow-sm transition-shadow duration-200 hover:shadow-lg ` +
           (large ? 'col-span-2 ' : '') +
           (selected ? 'ring-2 ring-blue-500' : '')
         }
       >
         {onToggleSelect && (
           <label
-            className="absolute top-2 left-2 z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md bg-white/90 shadow"
+            className="absolute top-2 left-2 z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md bg-card/90 shadow"
             title="Select image"
             onClick={(event) => event.stopPropagation()}
           >
@@ -196,7 +196,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
             />
           </label>
         )}
-        <div className={`w-full bg-gray-100 flex items-center justify-center overflow-hidden ` + (large ? 'h-72' : 'h-52')} >
+        <div className={`w-full bg-muted flex items-center justify-center overflow-hidden ` + (large ? 'h-72' : 'h-52')} >
           <img
             src={imageURL}
             alt={alt}
@@ -215,7 +215,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
           />
         </div>
       {filename && (
-        <div className="px-2 py-1 text-xs text-gray-600 truncate" title={filename}>
+        <div className="px-2 py-1 text-xs text-muted-foreground truncate" title={filename}>
           {filename}
         </div>
       )}

--- a/frontend/app/components/imageCard.tsx
+++ b/frontend/app/components/imageCard.tsx
@@ -33,6 +33,9 @@ interface ImageCardProps {
   /** when true, TV controls are shown regardless of size (useful for tests) */
   showControls?: boolean;
   tvs?: TV[];
+  selected?: boolean;
+  /** passing this shows the selection checkbox */
+  onToggleSelect?: (shiftKey: boolean) => void;
 }
 
 const ImageCard: React.FC<ImageCardProps> = ({
@@ -47,7 +50,9 @@ const ImageCard: React.FC<ImageCardProps> = ({
   onAssignSuccess,
   large,
   showControls
-  , tvs: tvsProp
+  , tvs: tvsProp,
+  selected,
+  onToggleSelect
 }) => {
   const [selectedTvIp, setSelectedTvIp] = useState("");
   const [error, setError] = useState("");
@@ -172,15 +177,38 @@ const ImageCard: React.FC<ImageCardProps> = ({
       <div
         className={
           `group relative flex flex-col overflow-hidden rounded-lg bg-white shadow-sm transition-shadow duration-200 hover:shadow-lg ` +
-          (large ? 'col-span-2' : '')
+          (large ? 'col-span-2 ' : '') +
+          (selected ? 'ring-2 ring-blue-500' : '')
         }
       >
+        {onToggleSelect && (
+          <label
+            className="absolute top-2 left-2 z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded-md bg-white/90 shadow"
+            title="Select image"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <input
+              type="checkbox"
+              className="h-4 w-4 accent-blue-600"
+              checked={!!selected}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) => onToggleSelect((event.nativeEvent as MouseEvent).shiftKey)}
+            />
+          </label>
+        )}
         <div className={`w-full bg-gray-100 flex items-center justify-center overflow-hidden ` + (large ? 'h-72' : 'h-52')} >
           <img
             src={imageURL}
             alt={alt}
             className={`max-h-full max-w-full object-contain transition-transform duration-200 group-hover:scale-105 cursor-pointer`}
-            onClick={() => {
+            onClick={(event) => {
+              // While selecting, clicking the image extends the selection instead of
+              // opening the modal — the usual file-manager behaviour.
+              if (onToggleSelect && (event.shiftKey || event.ctrlKey || event.metaKey)) {
+                event.preventDefault();
+                onToggleSelect(event.shiftKey);
+                return;
+              }
               setShowControlsModal(true);
               onClick?.();
             }}

--- a/frontend/app/components/imageGrid.tsx
+++ b/frontend/app/components/imageGrid.tsx
@@ -9,13 +9,26 @@ interface ImageGridProps {
   onDeleteImage?: (img: any) => void;
   onAssignSuccess?: () => void;
   tvs?: any[];
+  /** filenames currently selected; passing this turns the checkboxes on */
+  selectedFilenames?: string[];
+  onToggleSelect?: (filename: string, index: number, shiftKey: boolean) => void;
 }
 
-export default function ImageGrid({ images, albums = [], onImageClick, onDeleteImage, onAssignSuccess, tvs = [] }: ImageGridProps) {
+export default function ImageGrid({
+  images,
+  albums = [],
+  onImageClick,
+  onDeleteImage,
+  onAssignSuccess,
+  tvs = [],
+  selectedFilenames,
+  onToggleSelect,
+}: ImageGridProps) {
+  const selected = new Set(selectedFilenames || []);
   return (
     <div className="w-full p-4">
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-        {images.map((img: any) => (
+        {images.map((img: any, index: number) => (
           <ImageCard
             key={img.id}
             src={getUploadUrl(img.filename)}
@@ -27,6 +40,10 @@ export default function ImageGrid({ images, albums = [], onImageClick, onDeleteI
             onAssignSuccess={onAssignSuccess}
             onClick={() => onImageClick?.(img)}
             onDelete={onDeleteImage ? () => onDeleteImage(img) : undefined}
+            selected={selected.has(img.filename)}
+            onToggleSelect={
+              onToggleSelect ? (shiftKey) => onToggleSelect(img.filename, index, shiftKey) : undefined
+            }
           />
         ))}
       </div>

--- a/frontend/app/components/imageModal.tsx
+++ b/frontend/app/components/imageModal.tsx
@@ -78,20 +78,20 @@ const ImageModal: React.FC<ImageModalProps> = ({
   if (!isOpen) return null;
   return (
     <div className="fixed inset-0 bg-black/50 flex items-end sm:items-center justify-center z-50">
-      <div className="bg-white rounded-t-lg sm:rounded-lg w-full sm:w-96 max-h-[90vh] overflow-y-auto p-4 space-y-4">
+      <div className="bg-card rounded-t-lg sm:rounded-lg w-full sm:w-96 max-h-[90vh] overflow-y-auto p-4 space-y-4">
         {/* Close Button */}
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-sm font-semibold">Image Controls</h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700"
+            className="text-muted-foreground hover:text-foreground"
           >
             <XMarkIcon className="h-5 w-5" />
           </button>
         </div>
 
         {/* Image Preview */}
-        <div className="w-full bg-gray-100 rounded-lg flex items-center justify-center h-48 overflow-hidden">
+        <div className="w-full bg-muted rounded-lg flex items-center justify-center h-48 overflow-hidden">
           <img
             src={imageURL}
             alt={alt}
@@ -126,7 +126,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         {isLocalImage && availableAlbums.length > 0 && showAlbumAssign && (
           <div className="space-y-2 pt-2 border-t">
             <select
-              className="w-full border border-gray-300 px-2 py-2 rounded text-sm"
+              className="w-full border border-border px-2 py-2 rounded text-sm"
               value={selectedAlbum}
               onChange={e => setSelectedAlbum(e.target.value)}
             >
@@ -150,7 +150,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         {tvs.length > 0 && (
           <div className="space-y-3">
             <select
-              className="w-full border border-gray-300 px-3 py-2 rounded-lg text-sm"
+              className="w-full border border-border px-3 py-2 rounded-lg text-sm"
               value={selectedTvIp}
               onChange={e => setSelectedTvIp(e.target.value)}
               disabled={tvLoading}
@@ -193,7 +193,7 @@ const ImageModal: React.FC<ImageModalProps> = ({
         )}
 
         {tvs.length === 0 && (
-          <div className="text-sm text-gray-600 bg-gray-50 p-3 rounded-lg flex gap-2">
+          <div className="text-sm text-muted-foreground bg-background p-3 rounded-lg flex gap-2">
             <ExclamationCircleIcon className="h-5 w-5 flex-shrink-0" strokeWidth={1.8} />
             <span>No TVs configured. Go to Settings to add one.</span>
           </div>

--- a/frontend/app/components/loading-screen.tsx
+++ b/frontend/app/components/loading-screen.tsx
@@ -18,7 +18,7 @@ export default function LoadingScreen() {
         aria-label="Animated loading indicator"
       />
       <span className="sr-only">Loading content, please wait.</span>
-      <p className="text-center text-2xl md:text-4xl text-gray-500">Loading...</p>
+      <p className="text-center text-2xl md:text-4xl text-muted-foreground">Loading...</p>
     </div>
   )
 }

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -7,6 +7,8 @@ import {
   ScrollRestoration,
 } from "react-router";
 
+import { ThemeProvider } from "next-themes";
+
 import type { Route } from "./+types/root";
 import "./app.css";
 import LoadingScreen from "./components/loading-screen";
@@ -27,7 +29,8 @@ export const links: Route.LinksFunction = () => [
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
+    // suppressHydrationWarning: next-themes sets the class on <html> before React runs.
+    <html lang="en" suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -35,10 +38,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        {children}
-        <ScrollRestoration />
-        <Scripts />
-        <Toaster />
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          {children}
+          <ScrollRestoration />
+          <Scripts />
+          <Toaster />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/app/routes/albumPage.tsx
+++ b/frontend/app/routes/albumPage.tsx
@@ -165,7 +165,7 @@ export default function AlbumPage() {
       <div className="flex items-center justify-between mb-6">
         <button
           type="button"
-          className="text-sm text-blue-600 hover:underline"
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
           onClick={() => navigate('/gallery')}
         >
           ← Back to Gallery

--- a/frontend/app/routes/albumPage.tsx
+++ b/frontend/app/routes/albumPage.tsx
@@ -183,14 +183,14 @@ export default function AlbumPage() {
       {loading ? (
         <div>Loading album…</div>
       ) : !album ? (
-        <div className={error ? 'text-red-600' : 'text-gray-500'}>{error || 'Album not found.'}</div>
+        <div className={error ? 'text-red-600' : 'text-muted-foreground'}>{error || 'Album not found.'}</div>
       ) : (
         <>
-          <div className="bg-white rounded-lg shadow p-6 mb-8">
+          <div className="bg-card rounded-lg shadow p-6 mb-8">
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
               <div>
                 <h2 className="text-2xl font-bold">{album.name}</h2>
-                <p className="text-sm text-gray-500">{album.images.length} image{album.images.length === 1 ? '' : 's'} in this album</p>
+                <p className="text-sm text-muted-foreground">{album.images.length} image{album.images.length === 1 ? '' : 's'} in this album</p>
               </div>
 
               <div className="flex flex-col gap-2 md:items-end">
@@ -226,10 +226,10 @@ export default function AlbumPage() {
           </div>
 
 
-          <div className="bg-white rounded-lg shadow p-6">
+          <div className="bg-card rounded-lg shadow p-6">
             <h3 className="text-xl font-semibold mb-4">Album Images</h3>
             {album.images.length === 0 ? (
-              <div className="text-gray-500">No images in this album yet.</div>
+              <div className="text-muted-foreground">No images in this album yet.</div>
             ) : (
               <ImageGrid
                 images={album.images.map(img => ({ id: img.id, filename: img.filename, type: 'local' }))}

--- a/frontend/app/routes/albumPage.tsx
+++ b/frontend/app/routes/albumPage.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
+import { toast } from 'sonner';
 import ImageGrid from '../components/imageGrid';
+import { Button } from '../components/ui/button';
 import { fetchAlbum, fetchImages, addImageToAlbum, deleteAlbum, removeImageFromAlbum } from '../utils/galleryApi';
+import { getTvs, sendToTV, type TVInfo } from '../utils/tvApi';
 
 type AlbumImage = { id: number; filename: string };
 
@@ -21,6 +24,9 @@ export default function AlbumPage() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [successMessage, setSuccessMessage] = useState('');
+  const [tvs, setTvs] = useState<TVInfo[]>([]);
+  const [selectedTvIp, setSelectedTvIp] = useState('');
+  const [sendProgress, setSendProgress] = useState('');
 
   const loadAlbum = async () => {
     if (!albumId) return;
@@ -50,6 +56,59 @@ export default function AlbumPage() {
     loadAlbum();
     loadImages();
   }, [albumId]);
+
+  useEffect(() => {
+    getTvs()
+      .then((list: TVInfo[]) => {
+        setTvs(list || []);
+        if (list?.length) setSelectedTvIp(prev => prev || list[0].ip);
+      })
+      .catch(() => setTvs([]));
+  }, []);
+
+  const selectedTv = tvs.find(tv => tv.ip === selectedTvIp);
+
+  const handleSendAlbumToTv = async () => {
+    if (!album || !selectedTvIp || album.images.length === 0) return;
+    setBusy(true);
+    setError('');
+    setSuccessMessage('');
+
+    let sent = 0;
+    let consecutiveFailures = 0;
+    let lastError = '';
+
+    for (let i = 0; i < album.images.length; i++) {
+      const image = album.images[i];
+      setSendProgress(`Sending ${i + 1} of ${album.images.length}…`);
+      try {
+        // Only display the last one, otherwise the TV flips through the whole album.
+        await sendToTV({
+          payload: { ip: selectedTvIp, filename: image.filename },
+          display: i === album.images.length - 1,
+        });
+        sent++;
+        consecutiveFailures = 0;
+      } catch (e: any) {
+        lastError = e.message || 'Failed to send image';
+        consecutiveFailures++;
+        // A TV that failed three times in a row is not coming back mid-album.
+        if (consecutiveFailures >= 3) {
+          setError(`Stopped after ${i + 1} images: ${lastError}`);
+          break;
+        }
+      }
+    }
+
+    setSendProgress('');
+    setBusy(false);
+    if (sent > 0) {
+      toast.success(`Sent ${sent} of ${album.images.length} images to the TV`, { position: 'top-center' });
+      setSuccessMessage(`Sent ${sent} of ${album.images.length} images to the TV.`);
+    } else if (lastError) {
+      setError(lastError);
+    }
+  };
 
   const handleAddToAlbum = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -123,10 +182,8 @@ export default function AlbumPage() {
 
       {loading ? (
         <div>Loading album…</div>
-      ) : error ? (
-        <div className="text-red-600">{error}</div>
       ) : !album ? (
-        <div className="text-gray-500">Album not found.</div>
+        <div className={error ? 'text-red-600' : 'text-gray-500'}>{error || 'Album not found.'}</div>
       ) : (
         <>
           <div className="bg-white rounded-lg shadow p-6 mb-8">
@@ -135,7 +192,37 @@ export default function AlbumPage() {
                 <h2 className="text-2xl font-bold">{album.name}</h2>
                 <p className="text-sm text-gray-500">{album.images.length} image{album.images.length === 1 ? '' : 's'} in this album</p>
               </div>
+
+              <div className="flex flex-col gap-2 md:items-end">
+                <div className="flex flex-wrap items-center gap-2">
+                  <select
+                    value={selectedTvIp}
+                    onChange={e => setSelectedTvIp(e.target.value)}
+                    className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    disabled={busy || tvs.length === 0}
+                  >
+                    {tvs.length === 0 && <option value="">No TV configured</option>}
+                    {tvs.map(tv => (
+                      <option key={tv.ip} value={tv.ip}>{tv.name || tv.ip}</option>
+                    ))}
+                  </select>
+                  <Button
+                    onClick={handleSendAlbumToTv}
+                    disabled={busy || !selectedTvIp || album.images.length === 0}
+                  >
+                    {sendProgress || 'Send album to TV'}
+                  </Button>
+                </div>
+                {selectedTv?.delete_other_images_on_upload && (
+                  <p className="text-xs text-amber-600 md:text-right max-w-xs">
+                    This TV deletes its other images on every upload, so only the last image of the
+                    album would remain. Turn that option off in TV settings first.
+                  </p>
+                )}
+              </div>
             </div>
+            {error && <div className="text-red-600 text-sm mt-4">{error}</div>}
+            {successMessage && <div className="text-green-700 text-sm mt-2">{successMessage}</div>}
           </div>
 
 

--- a/frontend/app/routes/albumPage.tsx
+++ b/frontend/app/routes/albumPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 import ImageGrid from '../components/imageGrid';
 import { Button } from '../components/ui/button';
-import { fetchAlbum, fetchImages, addImageToAlbum, deleteAlbum, removeImageFromAlbum } from '../utils/galleryApi';
+import { fetchAlbum, deleteAlbum, removeImageFromAlbum } from '../utils/galleryApi';
 import { getTvs, sendToTV, type TVInfo } from '../utils/tvApi';
 
 type AlbumImage = { id: number; filename: string };
@@ -18,8 +18,6 @@ export default function AlbumPage() {
   const { albumId } = useParams();
   const navigate = useNavigate();
   const [album, setAlbum] = useState<AlbumDetail | null>(null);
-  const [images, setImages] = useState<string[]>([]);
-  const [selectedImage, setSelectedImage] = useState('');
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
@@ -43,18 +41,8 @@ export default function AlbumPage() {
     }
   };
 
-  const loadImages = async () => {
-    try {
-      const imgs = await fetchImages();
-      setImages(imgs || []);
-    } catch {
-      setImages([]);
-    }
-  };
-
   useEffect(() => {
     loadAlbum();
-    loadImages();
   }, [albumId]);
 
   useEffect(() => {
@@ -107,27 +95,6 @@ export default function AlbumPage() {
       setSuccessMessage(`Sent ${sent} of ${album.images.length} images to the TV.`);
     } else if (lastError) {
       setError(lastError);
-    }
-  };
-
-  const handleAddToAlbum = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!album || !selectedImage) {
-      setError('Select a valid image to add.');
-      return;
-    }
-    setBusy(true);
-    setError('');
-    setSuccessMessage('');
-    try {
-      await addImageToAlbum(album.name, selectedImage);
-      await loadAlbum();
-      setSuccessMessage('Image added to album successfully.');
-      setSelectedImage('');
-    } catch (e: any) {
-      setError(e.message || 'Failed to add image to album');
-    } finally {
-      setBusy(false);
     }
   };
 

--- a/frontend/app/routes/gallery.tsx
+++ b/frontend/app/routes/gallery.tsx
@@ -48,6 +48,10 @@ export default function Gallery() {
   const lastClickedIndex = useRef<number | null>(null);
   const [bulkAlbum, setBulkAlbum] = useState("");
   const [bulkBusy, setBulkBusy] = useState(false);
+  // Files waiting on an album choice after a drop.
+  const [pendingFiles, setPendingFiles] = useState<File[] | null>(null);
+  const [dropAlbumId, setDropAlbumId] = useState("");
+  const [dropNewAlbumName, setDropNewAlbumName] = useState("");
 
   async function loadLocalGallery() {
     setLoading(true);
@@ -181,11 +185,11 @@ export default function Gallery() {
   const [uploading, setUploading] = useState(false);
   const [uploadFile, setUploadFile] = useState<File|null>(null);
 
-  /** Resolve the album uploads should land in, creating it first when asked. */
-  async function resolveUploadAlbumId(): Promise<string | undefined> {
-    if (uploadAlbumId !== NEW_ALBUM) return uploadAlbumId || undefined;
+  /** Resolve a destination album id, creating the album first when asked for a new one. */
+  async function resolveAlbumId(albumId: string, newAlbumName: string): Promise<string | undefined> {
+    if (albumId !== NEW_ALBUM) return albumId || undefined;
 
-    const name = uploadNewAlbumName.trim();
+    const name = newAlbumName.trim();
     if (!name) throw new Error("Enter a name for the new album");
 
     const existing = albums.find(album => album.name === name);
@@ -194,9 +198,45 @@ export default function Gallery() {
 
     const target = updatedAlbums.find(album => album.name === name);
     if (!target) throw new Error("Failed to create album");
-    setUploadAlbumId(String(target.id));
-    setUploadNewAlbumName("");
     return String(target.id);
+  }
+
+  async function resolveUploadAlbumId(): Promise<string | undefined> {
+    const resolved = await resolveAlbumId(uploadAlbumId, uploadNewAlbumName);
+    if (uploadAlbumId === NEW_ALBUM && resolved) {
+      setUploadAlbumId(resolved);
+      setUploadNewAlbumName("");
+    }
+    return resolved;
+  }
+
+  /** Upload a batch of files into one album, reporting how it went. */
+  async function uploadFiles(files: File[], albumId: string | undefined) {
+    setUploading(true);
+    setError("");
+    let uploaded = 0;
+    let failed = 0;
+
+    for (const file of files) {
+      try {
+        await uploadImage(file, albumId);
+        uploaded++;
+      } catch (err) {
+        failed++;
+        console.error(`Failed to upload ${file.name}:`, err);
+      }
+    }
+
+    if (uploaded > 0) await loadLocalGallery();
+    setUploading(false);
+
+    if (failed === 0) {
+      toast.success(`Uploaded ${uploaded} image${uploaded === 1 ? "" : "s"}`, { position: "top-center" });
+    } else if (uploaded > 0) {
+      setError(`Uploaded ${uploaded}, but ${failed} failed`);
+    } else {
+      setError("No valid image files were uploaded");
+    }
   }
 
   async function handleUpload(e: React.FormEvent) {
@@ -216,48 +256,27 @@ export default function Gallery() {
     }
   }
 
+  /** Dropped files wait in a modal so the album can be chosen for this batch. */
   async function handleFilesDropped(files: File[]) {
-    setUploading(true);
     setError("");
-    let uploadedCount = 0;
-    let failedCount = 0;
+    setDropAlbumId(uploadAlbumId === NEW_ALBUM ? "" : uploadAlbumId);
+    setDropNewAlbumName("");
+    setPendingFiles(files);
+  }
 
+  async function confirmDropUpload(e: React.FormEvent) {
+    e.preventDefault();
+    if (!pendingFiles) return;
+    let albumId: string | undefined;
     try {
-      let albumId: string | undefined;
-      try {
-        albumId = await resolveUploadAlbumId();
-      } catch (e: any) {
-        setError(e.message || "Failed to prepare album");
-        return;
-      }
-
-      for (const file of files) {
-        try {
-          await uploadImage(file, albumId);
-          uploadedCount++;
-          toast.success("Uploaded successfully", {position: "top-center"})
-        } catch (err) {
-          failedCount++;
-          console.error(`Failed to upload ${file.name}:`, err);
-        }
-      }
-
-      // Reload gallery after uploads
-      if (uploadedCount > 0) {
-        await loadLocalGallery();
-        if (failedCount === 0) {
-          setTimeout(() => setError(""), 3000);
-        } else {
-          setError(`Uploaded ${uploadedCount}, but ${failedCount} failed`);
-        }
-      } else if (failedCount > 0) {
-        setError("No valid image files were uploaded");
-      }
-    } catch (err: any) {
-      setError(err.message || "Failed to upload images");
-    } finally {
-      setUploading(false);
+      albumId = await resolveAlbumId(dropAlbumId, dropNewAlbumName);
+    } catch (e: any) {
+      setError(e.message || "Failed to prepare album");
+      return;
     }
+    const files = pendingFiles;
+    setPendingFiles(null);
+    await uploadFiles(files, albumId);
   }
 
   function toggleSelect(filename: string, index: number, shiftKey: boolean) {
@@ -294,6 +313,37 @@ export default function Gallery() {
     }
   }
 
+  async function handleBulkDelete() {
+    if (selected.length === 0) return;
+    const count = selected.length;
+    if (!window.confirm(`Delete ${count} image${count === 1 ? "" : "s"}? This cannot be undone.`)) return;
+
+    setBulkBusy(true);
+    setError("");
+    let deleted = 0;
+    const failures: string[] = [];
+    for (const filename of selected) {
+      try {
+        await deleteImage(filename);
+        deleted++;
+      } catch (e: any) {
+        failures.push(filename);
+        console.error(`Failed to delete ${filename}:`, e);
+      }
+    }
+
+    setSelected([]);
+    lastClickedIndex.current = null;
+    await loadLocalGallery();
+    setBulkBusy(false);
+
+    if (failures.length === 0) {
+      toast.success(`Deleted ${deleted} image${deleted === 1 ? "" : "s"}`, { position: "top-center" });
+    } else {
+      setError(`Deleted ${deleted}, but ${failures.length} failed: ${failures.join(", ")}`);
+    }
+  }
+
   return (
     <ImageDropZone
       className="max-w-6xl mx-auto py-8 px-4"
@@ -305,7 +355,7 @@ export default function Gallery() {
             {/* Upload Image Form */}
             <div className="flex-1 bg-white rounded-lg shadow p-4">
               <h4 className="text-base font-semibold mb-3">Upload image</h4>
-              <p className="text-sm text-gray-600 mb-3">Drag and drop images anywhere or use the file input below</p>
+              <p className="text-sm text-gray-600 mb-3">Drag and drop images anywhere — you pick the album on drop — or use the file input below</p>
               <form onSubmit={handleUpload} className="flex flex-col gap-2">
                 <input
                   type="file"
@@ -365,7 +415,7 @@ export default function Gallery() {
               </button>
             )}
           </div>
-          <p className="text-sm text-gray-500 mb-2">Tick the boxes, or shift-click, to move several images at once.</p>
+          <p className="text-sm text-gray-500 mb-2">Tick the boxes, or shift-click, to move or delete several images at once.</p>
           {loading ? (
             <div>Loading...</div>
           ) : (
@@ -399,7 +449,14 @@ export default function Gallery() {
                 ))}
               </select>
               <Button onClick={handleBulkAssign} disabled={bulkBusy || !bulkAlbum}>
-                {bulkBusy ? "Moving…" : "Move"}
+                {bulkBusy ? "Working…" : "Move"}
+              </Button>
+              <Button
+                onClick={handleBulkDelete}
+                disabled={bulkBusy}
+                className="bg-red-600 hover:bg-red-700"
+              >
+                Delete
               </Button>
               <button
                 type="button"
@@ -415,6 +472,56 @@ export default function Gallery() {
             <h3 className="text-xl font-semibold align-middle">Albums</h3>
             <Button onClick={() => setShowCreateAlbumModal(true)}>Create album</Button>
           </div>
+
+          {/* Dropped files: pick where they land before anything is uploaded */}
+          {pendingFiles && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+              <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm relative">
+                <button
+                  className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 text-xl font-bold"
+                  onClick={() => setPendingFiles(null)}
+                  aria-label="Cancel"
+                >
+                  ×
+                </button>
+                <h4 className="text-base font-semibold mb-1">
+                  Upload {pendingFiles.length} image{pendingFiles.length === 1 ? "" : "s"}
+                </h4>
+                <p className="text-sm text-gray-600 mb-3">Choose where they should go.</p>
+                <form onSubmit={confirmDropUpload} className="flex flex-col gap-2">
+                  <select
+                    value={dropAlbumId}
+                    onChange={e => setDropAlbumId(e.target.value)}
+                    className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    autoFocus
+                  >
+                    <option value="">No album</option>
+                    {albums.map(album => (
+                      <option key={album.id} value={album.id}>{album.name}</option>
+                    ))}
+                    <option value={NEW_ALBUM}>+ New album…</option>
+                  </select>
+                  {dropAlbumId === NEW_ALBUM && (
+                    <input
+                      type="text"
+                      value={dropNewAlbumName}
+                      onChange={e => setDropNewAlbumName(e.target.value)}
+                      placeholder="New album name"
+                      className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    />
+                  )}
+                  <Button
+                    type="submit"
+                    className="px-4 py-2 text-sm"
+                    disabled={dropAlbumId === NEW_ALBUM && !dropNewAlbumName.trim()}
+                  >
+                    Upload
+                  </Button>
+                  {error && <div className="text-red-500 text-sm mt-1">{error}</div>}
+                </form>
+              </div>
+            </div>
+          )}
 
           {/* Modal for Create Album */}
           {showCreateAlbumModal && (

--- a/frontend/app/routes/gallery.tsx
+++ b/frontend/app/routes/gallery.tsx
@@ -350,12 +350,12 @@ export default function Gallery() {
       disabled={uploading}
       onFilesDropped={handleFilesDropped}
     >
-      <h1 className="text-2xl font-bold mb-6 mt-3 text-center text-gray-800">Gallery</h1>
+      <h1 className="text-2xl font-bold mb-6 mt-3 text-center text-foreground">Gallery</h1>
           <div className="flex flex-col md:flex-row gap-6 mb-8">
             {/* Upload Image Form */}
-            <div className="flex-1 bg-white rounded-lg shadow p-4">
+            <div className="flex-1 bg-card rounded-lg shadow p-4">
               <h4 className="text-base font-semibold mb-3">Upload image</h4>
-              <p className="text-sm text-gray-600 mb-3">Drag and drop images anywhere — you pick the album on drop — or use the file input below</p>
+              <p className="text-sm text-muted-foreground mb-3">Drag and drop images anywhere — you pick the album on drop — or use the file input below</p>
               <form onSubmit={handleUpload} className="flex flex-col gap-2">
                 <input
                   type="file"
@@ -364,7 +364,7 @@ export default function Gallery() {
                   className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                   disabled={uploading}
                 />
-                <label className="text-sm text-gray-600">Add to album</label>
+                <label className="text-sm text-muted-foreground">Add to album</label>
                 <select
                   value={uploadAlbumId}
                   onChange={e => setUploadAlbumId(e.target.value)}
@@ -415,7 +415,7 @@ export default function Gallery() {
               </button>
             )}
           </div>
-          <p className="text-sm text-gray-500 mb-2">Tick the boxes, or shift-click, to move or delete several images at once.</p>
+          <p className="text-sm text-muted-foreground mb-2">Tick the boxes, or shift-click, to move or delete several images at once.</p>
           {loading ? (
             <div>Loading...</div>
           ) : (
@@ -433,7 +433,7 @@ export default function Gallery() {
           )}
 
           {selected.length > 0 && (
-            <div className="sticky bottom-4 z-30 mb-8 flex flex-wrap items-center gap-3 rounded-lg border bg-white p-3 shadow-lg">
+            <div className="sticky bottom-4 z-30 mb-8 flex flex-wrap items-center gap-3 rounded-lg border bg-card p-3 shadow-lg">
               <span className="text-sm font-medium">
                 {selected.length} image{selected.length === 1 ? "" : "s"} selected
               </span>
@@ -460,7 +460,7 @@ export default function Gallery() {
               </Button>
               <button
                 type="button"
-                className="text-sm text-gray-500 hover:underline"
+                className="text-sm text-muted-foreground hover:underline"
                 onClick={() => { setSelected([]); lastClickedIndex.current = null; }}
               >
                 Clear
@@ -476,9 +476,9 @@ export default function Gallery() {
           {/* Dropped files: pick where they land before anything is uploaded */}
           {pendingFiles && (
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-              <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm relative">
+              <div className="bg-card rounded-lg shadow-lg p-6 w-full max-w-sm relative">
                 <button
-                  className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 text-xl font-bold"
+                  className="absolute top-2 right-2 text-muted-foreground hover:text-muted-foreground text-xl font-bold"
                   onClick={() => setPendingFiles(null)}
                   aria-label="Cancel"
                 >
@@ -487,7 +487,7 @@ export default function Gallery() {
                 <h4 className="text-base font-semibold mb-1">
                   Upload {pendingFiles.length} image{pendingFiles.length === 1 ? "" : "s"}
                 </h4>
-                <p className="text-sm text-gray-600 mb-3">Choose where they should go.</p>
+                <p className="text-sm text-muted-foreground mb-3">Choose where they should go.</p>
                 <form onSubmit={confirmDropUpload} className="flex flex-col gap-2">
                   <select
                     value={dropAlbumId}
@@ -526,9 +526,9 @@ export default function Gallery() {
           {/* Modal for Create Album */}
           {showCreateAlbumModal && (
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-              <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm relative">
+              <div className="bg-card rounded-lg shadow-lg p-6 w-full max-w-sm relative">
                 <button
-                  className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 text-xl font-bold"
+                  className="absolute top-2 right-2 text-muted-foreground hover:text-muted-foreground text-xl font-bold"
                   onClick={() => setShowCreateAlbumModal(false)}
                   aria-label="Close"
                 >
@@ -563,7 +563,7 @@ export default function Gallery() {
           )}
           
           <div className="space-y-4">
-            {albums.length === 0 && <div className="text-gray-500">No albums yet.</div>}
+            {albums.length === 0 && <div className="text-muted-foreground">No albums yet.</div>}
             {albums.map(album => (
               <AlbumCard
                 key={album.id}
@@ -580,7 +580,7 @@ export default function Gallery() {
             <>
               <hr className="my-8" />
               <h3 className="text-xl font-semibold mb-2">External Albums</h3>
-              {providerAlbums.length === 0 && <div className="text-gray-500">No external albums found.</div>}
+              {providerAlbums.length === 0 && <div className="text-muted-foreground">No external albums found.</div>}
               {providerAlbums.map(album => (
                 <div key={album.id} className="border rounded p-3 mb-2">
                   <div className="font-bold mb-2 flex items-center justify-between">
@@ -594,7 +594,7 @@ export default function Gallery() {
               ))}
               <h3 className="text-xl font-semibold mb-2" id="provider_images">External Images</h3>
               <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-4">
-                {providerImages.length === 0 && <span className="text-gray-400">No images selected</span>}
+                {providerImages.length === 0 && <span className="text-muted-foreground">No images selected</span>}
                 {providerImages.map(img => (
                   <ImageCard
                     key={img.id}

--- a/frontend/app/routes/gallery.tsx
+++ b/frontend/app/routes/gallery.tsx
@@ -1,7 +1,7 @@
 
 
-import React, { useEffect, useState } from "react";
-import { deleteImage, fetchImages, fetchAlbums, uploadImage, createAlbum, fetchProviderAlbumImages, fetchProviderAlbums, getProviderImageStreamUrl } from "../utils/galleryApi";
+import React, { useEffect, useRef, useState } from "react";
+import { deleteImage, fetchImages, fetchAlbums, uploadImage, createAlbum, addImagesToAlbum, fetchProviderAlbumImages, fetchProviderAlbums, getProviderImageStreamUrl } from "../utils/galleryApi";
 import ImageCard from "../components/imageCard";
 import AlbumCard from "~/components/AlbumCard";
 import ImageGrid from "~/components/imageGrid";
@@ -23,6 +23,8 @@ type GalleryImage = {
   metadata?: any;
 };
 
+const NEW_ALBUM = "__new__";
+
 export default function Gallery() {
   const [albums, setAlbums] = useState<Album[]>([]);
   const [images, setImages] = useState<GalleryImage[]>([]);
@@ -38,6 +40,14 @@ export default function Gallery() {
   const [tvs, setTvs] = useState<any[]>([]);
   const [creating, setCreating] = useState(false);
   const [showCreateAlbumModal, setShowCreateAlbumModal] = useState(false);
+  // Destination album for uploads: "" = none, NEW_ALBUM = create uploadNewAlbumName first.
+  const [uploadAlbumId, setUploadAlbumId] = useState("");
+  const [uploadNewAlbumName, setUploadNewAlbumName] = useState("");
+  // Multi-select: filenames, plus the last clicked row so shift-click can span a range.
+  const [selected, setSelected] = useState<string[]>([]);
+  const lastClickedIndex = useRef<number | null>(null);
+  const [bulkAlbum, setBulkAlbum] = useState("");
+  const [bulkBusy, setBulkBusy] = useState(false);
 
   async function loadLocalGallery() {
     setLoading(true);
@@ -171,13 +181,31 @@ export default function Gallery() {
   const [uploading, setUploading] = useState(false);
   const [uploadFile, setUploadFile] = useState<File|null>(null);
 
+  /** Resolve the album uploads should land in, creating it first when asked. */
+  async function resolveUploadAlbumId(): Promise<string | undefined> {
+    if (uploadAlbumId !== NEW_ALBUM) return uploadAlbumId || undefined;
+
+    const name = uploadNewAlbumName.trim();
+    if (!name) throw new Error("Enter a name for the new album");
+
+    const existing = albums.find(album => album.name === name);
+    const updatedAlbums: Album[] = existing ? albums : await createAlbum(name);
+    setAlbums(updatedAlbums);
+
+    const target = updatedAlbums.find(album => album.name === name);
+    if (!target) throw new Error("Failed to create album");
+    setUploadAlbumId(String(target.id));
+    setUploadNewAlbumName("");
+    return String(target.id);
+  }
+
   async function handleUpload(e: React.FormEvent) {
     e.preventDefault();
     if (!uploadFile) return;
     setUploading(true);
     setError("");
     try {
-      await uploadImage(uploadFile);
+      await uploadImage(uploadFile, await resolveUploadAlbumId());
       await loadLocalGallery();
       setUploadFile(null);
       setUploading(false)
@@ -195,9 +223,17 @@ export default function Gallery() {
     let failedCount = 0;
 
     try {
+      let albumId: string | undefined;
+      try {
+        albumId = await resolveUploadAlbumId();
+      } catch (e: any) {
+        setError(e.message || "Failed to prepare album");
+        return;
+      }
+
       for (const file of files) {
         try {
-          await uploadImage(file);
+          await uploadImage(file, albumId);
           uploadedCount++;
           toast.success("Uploaded successfully", {position: "top-center"})
         } catch (err) {
@@ -224,6 +260,40 @@ export default function Gallery() {
     }
   }
 
+  function toggleSelect(filename: string, index: number, shiftKey: boolean) {
+    setSelected(prev => {
+      const anchor = lastClickedIndex.current;
+      if (shiftKey && anchor !== null) {
+        const [from, to] = anchor <= index ? [anchor, index] : [index, anchor];
+        const range = images.slice(from, to + 1).map(img => img.filename);
+        const next = new Set(prev);
+        const selecting = !prev.includes(filename);
+        range.forEach(name => (selecting ? next.add(name) : next.delete(name)));
+        return Array.from(next);
+      }
+      return prev.includes(filename) ? prev.filter(name => name !== filename) : [...prev, filename];
+    });
+    lastClickedIndex.current = index;
+  }
+
+  async function handleBulkAssign() {
+    if (!bulkAlbum || selected.length === 0) return;
+    setBulkBusy(true);
+    setError("");
+    try {
+      await addImagesToAlbum(bulkAlbum, selected);
+      toast.success(`${selected.length} image${selected.length === 1 ? "" : "s"} moved to ${bulkAlbum}`, { position: "top-center" });
+      setSelected([]);
+      setBulkAlbum("");
+      lastClickedIndex.current = null;
+      await loadLocalGallery();
+    } catch (e: any) {
+      setError(e.message || "Failed to assign images to album");
+    } finally {
+      setBulkBusy(false);
+    }
+  }
+
   return (
     <ImageDropZone
       className="max-w-6xl mx-auto py-8 px-4"
@@ -244,6 +314,29 @@ export default function Gallery() {
                   className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
                   disabled={uploading}
                 />
+                <label className="text-sm text-gray-600">Add to album</label>
+                <select
+                  value={uploadAlbumId}
+                  onChange={e => setUploadAlbumId(e.target.value)}
+                  className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                  disabled={uploading}
+                >
+                  <option value="">No album</option>
+                  {albums.map(album => (
+                    <option key={album.id} value={album.id}>{album.name}</option>
+                  ))}
+                  <option value={NEW_ALBUM}>+ New album…</option>
+                </select>
+                {uploadAlbumId === NEW_ALBUM && (
+                  <input
+                    type="text"
+                    value={uploadNewAlbumName}
+                    onChange={e => setUploadNewAlbumName(e.target.value)}
+                    placeholder="New album name"
+                    className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                    disabled={uploading}
+                  />
+                )}
                 <Button
                   type="submit"
                   className=" px-4 py-2 rounded text-sm"
@@ -257,7 +350,22 @@ export default function Gallery() {
           </div>
 
 
-          <h3 className="text-xl font-semibold mb-2">Uploaded Images</h3>
+          <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+            <h3 className="text-xl font-semibold">Uploaded Images</h3>
+            {images.length > 0 && (
+              <button
+                type="button"
+                className="text-sm text-blue-600 hover:underline"
+                onClick={() => {
+                  setSelected(selected.length === images.length ? [] : images.map(img => img.filename));
+                  lastClickedIndex.current = null;
+                }}
+              >
+                {selected.length === images.length ? "Clear selection" : "Select all"}
+              </button>
+            )}
+          </div>
+          <p className="text-sm text-gray-500 mb-2">Tick the boxes, or shift-click, to move several images at once.</p>
           {loading ? (
             <div>Loading...</div>
           ) : (
@@ -268,7 +376,38 @@ export default function Gallery() {
                 tvs={tvs}
                 onDeleteImage={handleDeleteImage}
                 onAssignSuccess={loadLocalGallery}
+                selectedFilenames={selected}
+                onToggleSelect={toggleSelect}
               />
+            </div>
+          )}
+
+          {selected.length > 0 && (
+            <div className="sticky bottom-4 z-30 mb-8 flex flex-wrap items-center gap-3 rounded-lg border bg-white p-3 shadow-lg">
+              <span className="text-sm font-medium">
+                {selected.length} image{selected.length === 1 ? "" : "s"} selected
+              </span>
+              <select
+                value={bulkAlbum}
+                onChange={e => setBulkAlbum(e.target.value)}
+                className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                disabled={bulkBusy}
+              >
+                <option value="">Move to album…</option>
+                {albums.map(album => (
+                  <option key={album.id} value={album.name}>{album.name}</option>
+                ))}
+              </select>
+              <Button onClick={handleBulkAssign} disabled={bulkBusy || !bulkAlbum}>
+                {bulkBusy ? "Moving…" : "Move"}
+              </Button>
+              <button
+                type="button"
+                className="text-sm text-gray-500 hover:underline"
+                onClick={() => { setSelected([]); lastClickedIndex.current = null; }}
+              >
+                Clear
+              </button>
             </div>
           )}
 

--- a/frontend/app/routes/gallery.tsx
+++ b/frontend/app/routes/gallery.tsx
@@ -405,7 +405,7 @@ export default function Gallery() {
             {images.length > 0 && (
               <button
                 type="button"
-                className="text-sm text-blue-600 hover:underline"
+                className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 onClick={() => {
                   setSelected(selected.length === images.length ? [] : images.map(img => img.filename));
                   lastClickedIndex.current = null;
@@ -454,7 +454,7 @@ export default function Gallery() {
               <Button
                 onClick={handleBulkDelete}
                 disabled={bulkBusy}
-                className="bg-red-600 hover:bg-red-700"
+                className="bg-red-600 text-white hover:bg-red-700"
               >
                 Delete
               </Button>
@@ -586,7 +586,7 @@ export default function Gallery() {
                   <div className="font-bold mb-2 flex items-center justify-between">
                     <span>{album.name}</span>
                     <button
-                      className="text-xs text-blue-600 hover:underline ml-2"
+                      className="text-xs text-blue-600 dark:text-blue-400 hover:underline ml-2"
                       onClick={() => handleProviderAlbumSelect(album.id)}
                     >Load Images</button>
                   </div>

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -103,7 +103,7 @@ export default function Home() {
   ];
 
   return (
-    <div className="max-w-7xl mx-auto mt-12 p-8 bg-white rounded-2xl shadow-lg">
+    <div className="max-w-7xl mx-auto mt-12 p-8 bg-card rounded-2xl shadow-lg">
       <header className="text-center mb-8">
         <h1 className="text-4xl font-bold text-gray-900">FrameTV Art Gallery</h1>
       </header>
@@ -118,11 +118,11 @@ export default function Home() {
       </div>
 
       <section>
-        <h2 className="text-2xl font-semibold mt-8 mb-4 text-gray-800">Featured Artworks</h2>
+        <h2 className="text-2xl font-semibold mt-8 mb-4 text-foreground">Featured Artworks</h2>
         {loading ? (
-          <div className="text-center text-gray-400">Loading images...</div>
+          <div className="text-center text-muted-foreground">Loading images...</div>
         ) : images.length === 0 ? (
-          <div className="text-center text-gray-400">No images found. Upload some art!</div>
+          <div className="text-center text-muted-foreground">No images found. Upload some art!</div>
         ) : (
           <div className="flex gap-6 overflow-x-auto pb-2">
             {images.map((img, idx) => (
@@ -130,7 +130,7 @@ export default function Home() {
                 key={idx}
                 src={getUploadUrl(img)}
                 alt={`Artwork ${idx + 1}`}
-                className="w-48 h-32 object-cover rounded-xl shadow-md border border-gray-200"
+                className="w-48 h-32 object-cover rounded-xl shadow-md border border-border"
               />
             ))}
           </div>

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -105,7 +105,7 @@ export default function Home() {
   return (
     <div className="max-w-7xl mx-auto mt-12 p-8 bg-card rounded-2xl shadow-lg">
       <header className="text-center mb-8">
-        <h1 className="text-4xl font-bold text-gray-900">FrameTV Art Gallery</h1>
+        <h1 className="text-4xl font-bold text-foreground">FrameTV Art Gallery</h1>
       </header>
 
       {/* Responsive cards container */}

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -164,7 +164,7 @@ export default function Settings() {
           <div className="bg-card rounded-xl shadow-lg p-6 max-w-md w-full sm:w-auto flex flex-col items-center">
             <h3 className="text-lg font-semibold mb-2">Pairing TV</h3>
             <p className="mb-4 text-foreground text-center">Please accept the pairing request on your TV ({pairingIp}) to complete the process.</p>
-            <Button onClick={() => { setShowPairModal(false); setPairingIp(""); setAdding(false); }} className="bg-gray-300 text-foreground">
+            <Button onClick={() => { setShowPairModal(false); setPairingIp(""); setAdding(false); }} className="bg-secondary text-secondary-foreground hover:bg-secondary/80">
               Cancel
             </Button>
           </div>
@@ -181,7 +181,7 @@ export default function Settings() {
             <Input type="text" value={ip} onChange={e => setIp(e.target.value)} placeholder="IP address" required />
             <Input type="text" value={name} onChange={e => setName(e.target.value)} placeholder="Name (optional)" />
             <Input type="text" value={mac} onChange={e => setMac(e.target.value)} placeholder="MAC (optional)" />
-            <Button className="bg-blue-600 hover:bg-blue-900 disabled:opacity-50 sm:w-auto" disabled={adding}>
+            <Button className="bg-blue-600 text-white hover:bg-blue-900 disabled:opacity-50 sm:w-auto" disabled={adding}>
               {adding ? 'Adding…' : 'Add TV'}
             </Button>
           </form>
@@ -199,7 +199,7 @@ export default function Settings() {
                 <div key={tv.ip} className="bg-card shadow-md rounded-xl p-5 border border-border">
                   <div className="mb-4">
                     {tv.name && <div className="font-semibold text-foreground">{tv.name}</div>}
-                    <div className="font-mono text-blue-700">{tv.ip}</div>
+                    <div className="font-mono text-blue-700 dark:text-blue-400">{tv.ip}</div>
                     {tv.mac && <div className="text-xs bg-muted text-foreground px-2 py-1 rounded inline-block mt-2">{tv.mac}</div>}
                   </div>
 
@@ -220,7 +220,7 @@ export default function Settings() {
                     <button onClick={() => handleRemoveAllImages(tv.ip)} className="text-red-500 hover:text-red-700 text-sm font-medium">
                       Delete all Images from TV
                     </button>
-                    <Button onClick={() => handleRemoveTv(tv.ip)} className="bg-red-500 hover:bg-red-600 w-full">
+                    <Button onClick={() => handleRemoveTv(tv.ip)} className="bg-red-500 text-white hover:bg-red-600 w-full">
                       Remove TV
                     </Button>
                   </div>
@@ -265,10 +265,10 @@ export default function Settings() {
               <span>Enable Immich</span>
             </label>
             <div className="flex flex-col sm:flex-row gap-2 mt-2">
-              <Button type="submit" className="bg-blue-600 hover:bg-blue-900" disabled={providerSaving}>
+              <Button type="submit" className="bg-blue-600 text-white hover:bg-blue-900" disabled={providerSaving}>
                 {providerSaving ? 'Saving…' : 'Save Immich Config'}
               </Button>
-              <Button type="button" className="bg-gray-300 text-foreground" onClick={handleDeleteImmich} disabled={providerSaving}>
+              <Button type="button" className="bg-secondary text-secondary-foreground hover:bg-secondary/80" onClick={handleDeleteImmich} disabled={providerSaving}>
                 Delete Config
               </Button>
             </div>

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -157,14 +157,14 @@ export default function Settings() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col items-center bg-gray-50 w-full">
+    <div className="min-h-screen flex flex-col items-center bg-background w-full">
       {/* Pairing Modal */}
       {showPairModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
-          <div className="bg-white rounded-xl shadow-lg p-6 max-w-md w-full sm:w-auto flex flex-col items-center">
+          <div className="bg-card rounded-xl shadow-lg p-6 max-w-md w-full sm:w-auto flex flex-col items-center">
             <h3 className="text-lg font-semibold mb-2">Pairing TV</h3>
-            <p className="mb-4 text-gray-700 text-center">Please accept the pairing request on your TV ({pairingIp}) to complete the process.</p>
-            <Button onClick={() => { setShowPairModal(false); setPairingIp(""); setAdding(false); }} className="bg-gray-300 text-gray-700">
+            <p className="mb-4 text-foreground text-center">Please accept the pairing request on your TV ({pairingIp}) to complete the process.</p>
+            <Button onClick={() => { setShowPairModal(false); setPairingIp(""); setAdding(false); }} className="bg-gray-300 text-foreground">
               Cancel
             </Button>
           </div>
@@ -172,11 +172,11 @@ export default function Settings() {
       )}
 
       <div className="w-full px-4 mx-auto sm:max-w-2xl lg:max-w-4xl">
-        <h1 className="text-2xl font-bold mb-6 mt-3 text-center text-gray-800">TV Settings</h1>
+        <h1 className="text-2xl font-bold mb-6 mt-3 text-center text-foreground">TV Settings</h1>
 
         {/* Add TV Section */}
-        <div className="bg-white rounded-2xl border border-gray-200 p-5 mb-8">
-          <h2 className="text-lg font-semibold mb-4 text-gray-700">Add a New TV</h2>
+        <div className="bg-card rounded-2xl border border-border p-5 mb-8">
+          <h2 className="text-lg font-semibold mb-4 text-foreground">Add a New TV</h2>
           <form onSubmit={handleAddTv} className="flex flex-col sm:flex-row gap-3 mb-3">
             <Input type="text" value={ip} onChange={e => setIp(e.target.value)} placeholder="IP address" required />
             <Input type="text" value={name} onChange={e => setName(e.target.value)} placeholder="Name (optional)" />
@@ -189,18 +189,18 @@ export default function Settings() {
         </div>
 
         {/* TVs List */}
-        <div className="bg-white rounded-2xl border border-gray-200 p-5 mb-8">
-          <h2 className="text-lg font-semibold mb-4 text-gray-700">Your TVs</h2>
+        <div className="bg-card rounded-2xl border border-border p-5 mb-8">
+          <h2 className="text-lg font-semibold mb-4 text-foreground">Your TVs</h2>
           {tvs.length === 0 ? (
-            <div className="text-gray-400 text-center">No TVs added yet.</div>
+            <div className="text-muted-foreground text-center">No TVs added yet.</div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {tvs.map((tv) => (
-                <div key={tv.ip} className="bg-white shadow-md rounded-xl p-5 border border-gray-200">
+                <div key={tv.ip} className="bg-card shadow-md rounded-xl p-5 border border-border">
                   <div className="mb-4">
-                    {tv.name && <div className="font-semibold text-gray-700">{tv.name}</div>}
+                    {tv.name && <div className="font-semibold text-foreground">{tv.name}</div>}
                     <div className="font-mono text-blue-700">{tv.ip}</div>
-                    {tv.mac && <div className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded inline-block mt-2">{tv.mac}</div>}
+                    {tv.mac && <div className="text-xs bg-muted text-foreground px-2 py-1 rounded inline-block mt-2">{tv.mac}</div>}
                   </div>
 
                   <label className="flex items-center gap-2 text-sm mb-4">
@@ -231,10 +231,10 @@ export default function Settings() {
         </div>
 
         {/* Provider Settings */}
-        <div className="bg-white rounded-2xl border border-gray-200 p-5">
-          <h2 className="text-lg font-semibold mb-4 text-gray-700">External Providers</h2>
+        <div className="bg-card rounded-2xl border border-border p-5">
+          <h2 className="text-lg font-semibold mb-4 text-foreground">External Providers</h2>
           <form onSubmit={handleSaveImmich} className="flex flex-col gap-3 max-w-lg">
-            <div className="font-semibold text-gray-700">Immich</div>
+            <div className="font-semibold text-foreground">Immich</div>
             <Input
               type="text"
               value={immichHost}
@@ -268,7 +268,7 @@ export default function Settings() {
               <Button type="submit" className="bg-blue-600 hover:bg-blue-900" disabled={providerSaving}>
                 {providerSaving ? 'Saving…' : 'Save Immich Config'}
               </Button>
-              <Button type="button" className="bg-gray-300 text-gray-700" onClick={handleDeleteImmich} disabled={providerSaving}>
+              <Button type="button" className="bg-gray-300 text-foreground" onClick={handleDeleteImmich} disabled={providerSaving}>
                 Delete Config
               </Button>
             </div>

--- a/frontend/app/routes/tvGallery.tsx
+++ b/frontend/app/routes/tvGallery.tsx
@@ -140,7 +140,7 @@ export default function TVGallery() {
 
           {loading ? (
             <div className="flex items-center justify-center py-12">
-              <ArrowPathIcon className="w-8 h-8 animate-spin text-blue-600" />
+              <ArrowPathIcon className="w-8 h-8 animate-spin text-blue-600 dark:text-blue-400" />
             </div>
           ) : images.length === 0 ? (
             <div className="text-center py-12">

--- a/frontend/app/routes/tvGallery.tsx
+++ b/frontend/app/routes/tvGallery.tsx
@@ -114,12 +114,12 @@ export default function TVGallery() {
   return (
     <div className="container mx-auto px-4 py-6 max-w-2xl">
       <div className="flex items-center gap-2 mb-6">
-        <h1 className="text-2xl font-bold mb-6 mt-3 text-center text-gray-800">TV Settings</h1>
+        <h1 className="text-2xl font-bold mb-6 mt-3 text-center text-foreground">TV Settings</h1>
       </div>
 
       {tvs.length === 0 ? (
         <div className="text-center py-12">
-          <p className="text-gray-500">No TVs configured</p>
+          <p className="text-muted-foreground">No TVs configured</p>
         </div>
       ) : (
         <>
@@ -128,7 +128,7 @@ export default function TVGallery() {
             <select
               value={selectedTvIp}
               onChange={(e) => setSelectedTvIp(e.target.value)}
-              className="w-full p-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-950"
+              className="w-full p-2 border border-border rounded-lg bg-card"
             >
               {tvs.map((tv) => (
                 <option key={tv.ip} value={tv.ip}>
@@ -144,11 +144,11 @@ export default function TVGallery() {
             </div>
           ) : images.length === 0 ? (
             <div className="text-center py-12">
-              <p className="text-gray-500">No images on TV</p>
+              <p className="text-muted-foreground">No images on TV</p>
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-sm text-gray-600 mb-4">
+              <p className="text-sm text-muted-foreground mb-4">
                 {images.length} image{images.length !== 1 ? "s" : ""} on TV
               </p>
               {images.map((image) => (

--- a/frontend/app/utils/galleryApi.ts
+++ b/frontend/app/utils/galleryApi.ts
@@ -75,9 +75,12 @@ export async function fetchAlbums() {
   return (await res.json()).albums;
 }
 
-export async function uploadImage(file: File) {
+export async function uploadImage(file: File, albumId?: string | number) {
   const formData = new FormData();
   formData.append('file', file);
+  if (albumId !== undefined && albumId !== null && albumId !== '') {
+    formData.append('album_id', String(albumId));
+  }
 
   const res = await fetch(`${API_BASE}/api/upload`, {
     method: 'POST',
@@ -105,6 +108,16 @@ export async function addImageToAlbum(album: string, image: string) {
     body: JSON.stringify({ image }),
   });
   if (!res.ok) throw new Error((await res.json()).error || 'Failed to add image');
+  return (await res.json()).albums;
+}
+
+export async function addImagesToAlbum(album: string, images: string[]) {
+  const res = await fetch(`${API_BASE}/api/albums/${encodeURIComponent(album)}/add`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ images }),
+  });
+  if (!res.ok) throw new Error((await res.json()).error || 'Failed to add images');
   return (await res.json()).albums;
 }
 

--- a/frontend/app/welcome/welcome.tsx
+++ b/frontend/app/welcome/welcome.tsx
@@ -20,8 +20,8 @@ export function Welcome() {
           </div>
         </header>
         <div className="max-w-[300px] w-full space-y-6 px-4">
-          <nav className="rounded-3xl border border-gray-200 p-6 dark:border-gray-700 space-y-4">
-            <p className="leading-6 text-gray-700 dark:text-gray-200 text-center">
+          <nav className="rounded-3xl border border-border p-6 dark:border-gray-700 space-y-4">
+            <p className="leading-6 text-foreground dark:text-gray-200 text-center">
               What&apos;s next?
             </p>
             <ul>

--- a/tests/test_album_api.py
+++ b/tests/test_album_api.py
@@ -1,0 +1,100 @@
+"""Covers picking an album at upload time and assigning several images at once.
+
+Run with: pytest tests/test_album_api.py
+"""
+
+import io
+
+import pytest
+from PIL import Image as PILImage
+
+import app as backend
+
+
+@pytest.fixture
+def client():
+    backend.app.config["TESTING"] = True
+    with backend.app.app_context():
+        backend.db.drop_all()
+        backend.db.create_all()
+    return backend.app.test_client()
+
+
+def png_bytes():
+    buf = io.BytesIO()
+    PILImage.new("RGB", (4, 4), "red").save(buf, format="PNG")
+    buf.seek(0)
+    return buf
+
+
+def upload(client, name, album_id=None):
+    data = {"file": (png_bytes(), name)}
+    if album_id is not None:
+        data["album_id"] = str(album_id)
+    return client.post("/api/upload", data=data, content_type="multipart/form-data")
+
+
+def album_named(payload, name):
+    return next(album for album in payload["albums"] if album["name"] == name)
+
+
+def test_upload_lands_in_the_chosen_album(client):
+    created = client.post("/api/albums", json={"name": "Holidays"}).get_json()
+    album_id = album_named(created, "Holidays")["id"]
+
+    res = upload(client, "beach.png", album_id=album_id)
+    assert res.status_code == 200
+    assert res.get_json()["album_id"] == album_id
+
+    albums = client.get("/api/albums").get_json()
+    assert album_named(albums, "Holidays")["images"] == ["beach.png"]
+
+
+def test_upload_without_an_album_still_works(client):
+    res = upload(client, "orphan.png")
+    assert res.status_code == 200
+    assert res.get_json()["album_id"] is None
+
+
+@pytest.mark.parametrize("album_id,expected", [(999, 404), ("not-a-number", 400)])
+def test_upload_rejects_unusable_album_ids(client, album_id, expected):
+    assert upload(client, "ghost.png", album_id=album_id).status_code == expected
+
+
+def test_reupload_reuses_the_existing_image_row(client):
+    upload(client, "beach.png")
+    upload(client, "beach.png")
+    with backend.app.app_context():
+        assert backend.Image.query.filter_by(filename="beach.png").count() == 1
+
+
+def test_bulk_assign_moves_every_selected_image(client):
+    client.post("/api/albums", json={"name": "Holidays"})
+    for name in ("a.png", "b.png", "c.png"):
+        upload(client, name)
+
+    res = client.post("/api/albums/Holidays/add", json={"images": ["a.png", "b.png", "c.png"]})
+    assert res.status_code == 200
+    assert set(album_named(res.get_json(), "Holidays")["images"]) == {"a.png", "b.png", "c.png"}
+
+
+def test_single_image_assign_still_moves_between_albums(client):
+    client.post("/api/albums", json={"name": "Holidays"})
+    client.post("/api/albums", json={"name": "Winter"})
+    upload(client, "a.png", album_id=album_named(client.get("/api/albums").get_json(), "Holidays")["id"])
+
+    res = client.post("/api/albums/Winter/add", json={"image": "a.png"})
+    assert res.status_code == 200
+    assert album_named(res.get_json(), "Winter")["images"] == ["a.png"]
+    assert album_named(res.get_json(), "Holidays")["images"] == []
+
+
+@pytest.mark.parametrize("payload", [{}, {"images": []}, {"images": ["ok.png", 2]}])
+def test_invalid_bulk_payloads_are_rejected(client, payload):
+    client.post("/api/albums", json={"name": "Winter"})
+    assert client.post("/api/albums/Winter/add", json=payload).status_code == 400
+
+
+def test_assigning_to_a_missing_album_is_a_404(client):
+    upload(client, "a.png")
+    assert client.post("/api/albums/Nope/add", json={"images": ["a.png"]}).status_code == 404


### PR DESCRIPTION
Second half of the split you asked for in #61. Implements #59, plus a light and dark mode.
Independent of the TV reliability PR — both are based on `main` and green on their own.

## #59: albums

- The upload form takes a destination album, including a "new album" option that creates it
  first. Drag-and-drop opens a small dialog asking the same thing, since the form's choice
  is invisible at drop time.
- The gallery has checkboxes and shift-click ranges, with a bar to move the selection into
  an album or delete it in one action.
- `POST /api/albums/<name>/add` accepts `{"images": [...]}` alongside the existing
  `{"image": …}`, so old and new callers share one endpoint.
- The album page gains a TV picker and a button that sends every image in the album, in
  order, with progress. Only the last is displayed, otherwise the TV flips through the
  album as it uploads; it warns when the chosen TV has "delete other images on upload"
  enabled, which would leave only that last image standing.
- Re-uploading a filename no longer leaves a second database row pointing at the same
  overwritten file.

## Light and dark mode

`next-themes` was already a dependency and `sonner.tsx` already called `useTheme`, but
nothing rendered a provider, so the `.dark` tokens in `app.css` were dead weight. There is
now a toggle in the header, starting from the system preference and remembered afterwards.

The pages were written in fixed light colours, so they ignored those tokens: 86 occurrences
across 14 files now use the semantic ones that already had both values — `bg-white` becomes
`bg-card`, grey text becomes `foreground` or `muted-foreground`, grey borders become
`border-border`. The header bar is deliberately dark in both themes and keeps its fixed
colours.

Two supporting fixes: the `dark` variant now matches the element carrying the class rather
than only its descendants, because next-themes puts it on `<html>`; and `color-scheme`
follows the chosen theme instead of the OS preference, so native selects and checkboxes
cannot end up dark inside a light page.

Auditing contrast on every text node turned up five places that only worked against one
background — the home page title among them, invisible in dark mode. Every text node on the
home, gallery and settings pages now clears 4.5:1 in both themes.

## Testing

Eleven tests cover the album endpoints: uploading into an album, rejecting unusable album
ids, the bulk assign, that the single-image caller still works, and that re-uploading a
filename reuses its row. The flows were also driven in a browser against a container —
selecting and deleting, dropping files into a newly created album, and toggling the theme.

This PR carries the same infrastructure commit as the TV reliability one (lockfile fix,
`.gitattributes`, CI workflow) so it is green on its own; whichever lands second sees it as
a no-op.
