### PR TITLE
Stamp a newly created database so migrations do not replay over it

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,17 +100,25 @@ app.register_blueprint(provider_config_routes)
 
 # ...models are now imported from models.py...
 
+migrate = Migrate(app, db)
+
+
 # Create database
 def init_db():
     """Ensure database and all tables exist."""
     with app.app_context():
+        fresh = not os.path.exists(frametv_db_path)
         app.logger.info("Initializing database")
         db.create_all()
-        app.logger.info("Database initialized")
+        if fresh:
+            from flask_migrate import stamp
+            stamp(revision='head')
+            app.logger.info("New database created and stamped as up to date")
+        else:
+            app.logger.info("Database initialized")
 
 # Initialize database on startup
 init_db()
-migrate = Migrate(app, db)
 
 
 # --- Helpers ---

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,123 @@
+"""Checks that the database is usable however it was created.
+
+These run `flask db upgrade` in a subprocess against a throwaway data directory,
+because that is what the container entrypoint does and the failure being guarded
+against only appears there — the in-process fixtures elsewhere call create_all()
+directly and never touch alembic.
+
+Run with: pytest tests/test_migrations.py
+"""
+
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def head_revision() -> str:
+    """The revision with nothing revising it."""
+    versions = PROJECT_ROOT / "migrations" / "versions"
+    revisions, parents = set(), set()
+    for path in versions.glob("*.py"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if line.startswith("revision ="):
+                revisions.add(line.split("=", 1)[1].strip().strip("'\""))
+            elif line.startswith("down_revision ="):
+                parents.add(line.split("=", 1)[1].strip().strip("'\""))
+    heads = revisions - parents
+    assert len(heads) == 1, f"expected a single head, found {heads}"
+    return heads.pop()
+
+
+def run_upgrade(data_dir: Path):
+    environment = {
+        **os.environ,
+        "FRAME_TV_DATA": str(data_dir),
+        "FLASK_APP": "app.py",
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "flask", "db", "upgrade"],
+        cwd=PROJECT_ROOT,
+        env=environment,
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+
+
+def stamped_revision(data_dir: Path):
+    connection = sqlite3.connect(data_dir / "instance" / "frametv.db")
+    try:
+        return [row[0] for row in connection.execute("SELECT version_num FROM alembic_version")]
+    finally:
+        connection.close()
+
+
+@pytest.fixture
+def data_dir():
+    path = Path(tempfile.mkdtemp(prefix="frametv-migrations-"))
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def test_a_fresh_install_ends_up_at_head(data_dir):
+    """The container has to boot on an empty volume, not just on an upgraded one."""
+    result = run_upgrade(data_dir)
+    assert result.returncode == 0, f"upgrade failed:\n{result.stderr[-2000:]}"
+    assert stamped_revision(data_dir) == [head_revision()]
+
+
+def test_a_fresh_install_is_stamped_rather_than_replayed(data_dir):
+    """create_all() builds the whole schema, so the migrations must not run over it.
+
+    Replaying them is what used to abort the first migration that rebuilds a table:
+    alembic reflects it and finds columns create_all had already added.
+    """
+    result = run_upgrade(data_dir)
+    assert "Running upgrade" not in result.stderr + result.stdout
+    assert "stamp" in (result.stderr + result.stdout).lower()
+
+
+def test_upgrading_twice_changes_nothing(data_dir):
+    run_upgrade(data_dir)
+    before = stamped_revision(data_dir)
+    result = run_upgrade(data_dir)
+    assert result.returncode == 0, f"second upgrade failed:\n{result.stderr[-2000:]}"
+    assert stamped_revision(data_dir) == before
+
+
+def test_an_existing_database_still_migrates(data_dir):
+    """A volume from an older release must be carried forward, not stamped over."""
+    run_upgrade(data_dir)
+    head = head_revision()
+
+    # Rewind to the previous revision to stand in for a database from an older image.
+    database = data_dir / "instance" / "frametv.db"
+    connection = sqlite3.connect(database)
+    try:
+        parents = {}
+        for path in (PROJECT_ROOT / "migrations" / "versions").glob("*.py"):
+            text = path.read_text(encoding="utf-8")
+            revision = down = None
+            for line in text.splitlines():
+                if line.startswith("revision ="):
+                    revision = line.split("=", 1)[1].strip().strip("'\"")
+                elif line.startswith("down_revision ="):
+                    down = line.split("=", 1)[1].strip().strip("'\"")
+            parents[revision] = down
+        previous = parents[head]
+        connection.execute("UPDATE alembic_version SET version_num = ?", (previous,))
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = run_upgrade(data_dir)
+    assert result.returncode == 0, f"upgrade failed:\n{result.stderr[-2000:]}"
+    assert stamped_revision(data_dir) == [head], "the pending migration should have run"


### PR DESCRIPTION
A latent problem in how the database gets created, independent of #62 and #63 — small
enough to review on its own.

## What happens

`init_db()` calls `create_all()`, which builds the schema straight from the models, but
nothing records that the database is already current. `alembic_version` stays empty, so
`flask db upgrade` replays the whole chain over tables that are already complete.

**main is not broken today.** The replay succeeds because no migration yet has to rebuild
a table containing a column `create_all()` added ahead of it. SQLite cannot alter a column
in place, so alembic reflects the table and recreates it — and the first time a new model
column meets `a16beaf2617d`, which alters `image.album_id`, the upgrade aborts:

```
sqlalchemy.exc.CircularDependencyError: Circular dependency detected. ('created_at', 'sha256')
```

The container exits before gunicorn starts a worker. Existing installations are unaffected,
since their `alembic_version` is populated — it is a fresh volume that gets a dead
container.

I ran into it adding a column to `Image` in a fork, and published an image that would not
start on a new install before I understood why. It seemed worth sending back, since any
future column on `Image` will do the same to everyone starting fresh.

**To reproduce on main:** add any column to the `Image` model, delete the data directory,
run `flask db upgrade`.

## The change

A database created by `init_db()` is stamped as up to date, which is what `upgrade`
expects to find. An existing one is left alone and migrates exactly as before. `Migrate`
is now constructed above `init_db()` so `stamp()` has its configuration.

That is the whole fix — five lines and a docstring explaining why they are there.

## Tests

The database tests in a normal suite call `create_all()` directly and never touch alembic,
which is precisely why this hides. These run `flask db upgrade` in a subprocess against a
throwaway data directory, the way the entrypoint does:

- a fresh install reaches head
- it gets there by being stamped rather than replaying the migrations
- upgrading twice is a no-op
- a database left at an earlier revision still migrates forward

The second is the one that fails on main today. The others guard the behaviour this
touches, so a later change cannot quietly reintroduce the replay.

The branch also carries the CI workflow and lockfile fix from #62, so the tests actually
run here; if #62 lands first this becomes a no-op. Happy to rebase it out if you would
rather take this one first.
