### PR TITLE
feat: Rotate through an album on a TV at a chosen interval

### DIFF
--- a/app.py
+++ b/app.py
@@ -123,6 +123,21 @@ def init_db():
 # Initialize database on startup
 init_db()
 
+# One gunicorn worker out of several picks up the slideshow loop; see utils/slideshow.py.
+app.config['SLIDESHOW_LOCK_PATH'] = os.path.join(INSTANCE_FOLDER, 'slideshow.lock')
+if os.environ.get('FRAME_TV_SLIDESHOW', '1').lower() not in ('0', 'false', 'no'):
+    from utils import slideshow as _slideshow
+
+    _slideshow.start(
+        app,
+        db,
+        (TV, Image, UploadedImage),
+        play_uploaded_content,
+        is_art_mode_on,
+        (FrameTVError, OSError),
+        (ResponseError,),
+    )
+
 
 # --- Helpers ---
 def allowed_file(filename: str) -> bool:
@@ -483,7 +498,10 @@ def api_get_tvs():
             'ip': tv.ip,
             'name': tv.name,
             'mac': tv.mac,
-            'delete_other_images_on_upload': getattr(tv, 'delete_other_images_on_upload', False)
+            'delete_other_images_on_upload': getattr(tv, 'delete_other_images_on_upload', False),
+            'slideshow_enabled': bool(getattr(tv, 'slideshow_enabled', False)),
+            'slideshow_album_id': getattr(tv, 'slideshow_album_id', None),
+            'slideshow_interval_minutes': getattr(tv, 'slideshow_interval_minutes', None),
         } for tv in tvs
     ]}
 
@@ -492,9 +510,40 @@ def api_update_tv(ip):
     tv = TV.query.filter_by(ip=ip).first()
     if not tv:
         return {'error': 'TV not found'}, 404
-    data = request.get_json()
+    data = request.get_json() or {}
     if 'delete_other_images_on_upload' in data:
         tv.delete_other_images_on_upload = bool(data['delete_other_images_on_upload'])
+
+    if 'slideshow_enabled' in data:
+        tv.slideshow_enabled = bool(data['slideshow_enabled'])
+    if 'slideshow_album_id' in data:
+        album_id = data['slideshow_album_id']
+        if album_id in (None, ''):
+            tv.slideshow_album_id = None
+        else:
+            try:
+                album = Album.query.get(int(album_id))
+            except (TypeError, ValueError):
+                return {'error': 'Invalid album'}, 400
+            if not album:
+                return {'error': 'Album not found'}, 404
+            tv.slideshow_album_id = album.id
+    if 'slideshow_interval_minutes' in data:
+        raw = data['slideshow_interval_minutes']
+        if raw in (None, ''):
+            tv.slideshow_interval_minutes = None
+        else:
+            try:
+                minutes = int(raw)
+            except (TypeError, ValueError):
+                return {'error': 'Interval must be a whole number of minutes'}, 400
+            if minutes < 1:
+                return {'error': 'Interval must be at least one minute'}, 400
+            tv.slideshow_interval_minutes = minutes
+
+    if tv.slideshow_enabled and not (tv.slideshow_album_id and tv.slideshow_interval_minutes):
+        return {'error': 'Pick an album and an interval before enabling the slideshow'}, 400
+
     db.session.commit()
     return {'success': True}
 

--- a/frontend/app/routes/settings.tsx
+++ b/frontend/app/routes/settings.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Link } from 'react-router'
-import { getTvs, addTv, removeTv, removeAllTvImages, updateTv } from '~/utils/tvApi';
+import { getTvs, addTv, removeTv, removeAllTvImages, updateTv, type TVUpdate } from '~/utils/tvApi';
+import { fetchAlbums } from '~/utils/galleryApi';
 import { Input } from '~/components/ui/input';
 import { Button } from '~/components/ui/button';
 import { getProviders, setProvider, getProvider, deleteProvider } from '~/utils/providerApi';
@@ -12,6 +13,9 @@ interface TV {
   name?: string;
   mac?: string;
   delete_other_images_on_upload?: boolean;
+  slideshow_enabled?: boolean;
+  slideshow_album_id?: number | null;
+  slideshow_interval_minutes?: number | null;
 }
 
 export default function Settings() {
@@ -32,6 +36,9 @@ export default function Settings() {
   const [immichEnabled, setImmichEnabled] = React.useState(false);
   const [providerError, setProviderError] = React.useState("");
   const [providerSaving, setProviderSaving] = React.useState(false);
+
+  // Albums feed the slideshow picker.
+  const [albums, setAlbums] = React.useState<{ id: string; name: string }[]>([]);
 
   // Fetch TVs
   const fetchTvs = React.useCallback(async () => {
@@ -61,6 +68,7 @@ export default function Settings() {
   React.useEffect(() => {
     fetchTvs();
     fetchProviders();
+    fetchAlbums().then(setAlbums).catch(() => setAlbums([]));
   }, [fetchTvs, fetchProviders]);
 
   // TV handlers
@@ -115,6 +123,18 @@ export default function Settings() {
       await fetchTvs();
     } catch (e: any) {
       setError(e.message || 'Failed to update TV setting');
+    }
+  };
+
+  const handleSlideshow = async (tvIp: string, updates: TVUpdate) => {
+    setError('');
+    try {
+      await updateTv(tvIp, updates);
+    } catch (e: any) {
+      setError(e.message || 'Failed to update the slideshow');
+    } finally {
+      // Refetched either way, so a rejected change does not linger in the form.
+      await fetchTvs();
     }
   };
 
@@ -212,6 +232,48 @@ export default function Settings() {
                     />
                     <span>Delete other images on upload</span>
                   </label>
+
+                  <fieldset className="mb-4 border border-gray-200 rounded-lg p-3">
+                    <legend className="text-sm font-medium px-1">Slideshow</legend>
+                    <p className="text-xs text-gray-500 mb-2">
+                      Rotates through images of an album that are already on this TV. It only
+                      moves art that is already on screen, so it never interrupts what you are
+                      watching.
+                    </p>
+                    <div className="flex flex-col gap-2">
+                      <select
+                        value={tv.slideshow_album_id ?? ''}
+                        onChange={e => handleSlideshow(tv.ip, { slideshow_album_id: e.target.value || null })}
+                        aria-label="Slideshow album"
+                        className="border px-2 py-2 rounded text-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+                      >
+                        <option value="">No album</option>
+                        {albums.map(album => (
+                          <option key={album.id} value={album.id}>{album.name}</option>
+                        ))}
+                      </select>
+                      <div className="flex items-center gap-2">
+                        <Input
+                          type="number"
+                          min={1}
+                          value={tv.slideshow_interval_minutes ?? ''}
+                          onChange={e => handleSlideshow(tv.ip, { slideshow_interval_minutes: e.target.value || null })}
+                          placeholder="Every … minutes"
+                          aria-label="Slideshow interval in minutes"
+                        />
+                        <span className="text-sm text-gray-500 whitespace-nowrap">min</span>
+                      </div>
+                      <label className="flex items-center gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={!!tv.slideshow_enabled}
+                          onChange={e => handleSlideshow(tv.ip, { slideshow_enabled: e.target.checked })}
+                          className="accent-blue-600"
+                        />
+                        <span>Enabled</span>
+                      </label>
+                    </div>
+                  </fieldset>
 
                   <div className="flex flex-col gap-2">
                     <Link to={`/tv-gallery?ip=${encodeURIComponent(tv.ip)}`} className="bg-blue-500 hover:bg-blue-600 text-white text-sm font-medium py-2 px-4 rounded-lg text-center">

--- a/frontend/app/utils/tvApi.ts
+++ b/frontend/app/utils/tvApi.ts
@@ -14,6 +14,16 @@ export interface TVInfo {
   name?: string;
   mac?: string;
   delete_other_images_on_upload?: boolean;
+  slideshow_enabled?: boolean;
+  slideshow_album_id?: number | null;
+  slideshow_interval_minutes?: number | null;
+}
+
+export interface TVUpdate {
+  delete_other_images_on_upload?: boolean;
+  slideshow_enabled?: boolean;
+  slideshow_album_id?: number | string | null;
+  slideshow_interval_minutes?: number | string | null;
 }
 
 export class TVError extends Error {
@@ -44,7 +54,7 @@ export async function getTvs() {
   return (await res.json()).tvs;
 }
 
-export async function updateTv(ip: string, updates: { delete_other_images_on_upload?: boolean }) {
+export async function updateTv(ip: string, updates: TVUpdate) {
   const res = await fetch(`${API_BASE}/api/tvs/${encodeURIComponent(ip)}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },

--- a/migrations/versions/b7c3d1e9f204_add_tv_slideshow_settings.py
+++ b/migrations/versions/b7c3d1e9f204_add_tv_slideshow_settings.py
@@ -1,0 +1,52 @@
+"""Add the per-TV slideshow settings
+
+Additive and off by default, so an existing database behaves exactly as before until
+a slideshow is configured.
+
+Revision ID: b7c3d1e9f204
+Revises: 601a7cee3cbb
+Create Date: 2026-08-10 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'b7c3d1e9f204'
+down_revision = '601a7cee3cbb'
+branch_labels = None
+depends_on = None
+
+
+COLUMNS = [
+    ('slideshow_enabled', sa.Column('slideshow_enabled', sa.Boolean(), nullable=False, server_default=sa.text('0'))),
+    ('slideshow_album_id', sa.Column('slideshow_album_id', sa.Integer(), nullable=True)),
+    ('slideshow_interval_minutes', sa.Column('slideshow_interval_minutes', sa.Integer(), nullable=True)),
+    ('slideshow_last_run', sa.Column('slideshow_last_run', sa.DateTime(), nullable=True)),
+    ('slideshow_last_content_id', sa.Column('slideshow_last_content_id', sa.String(length=255), nullable=True)),
+]
+
+
+def _existing_columns():
+    return {column['name'] for column in sa.inspect(op.get_bind()).get_columns('tv')}
+
+
+def upgrade():
+    # create_all() runs when the app starts, so on a fresh install these columns may
+    # already exist by the time this runs. Adding them again would abort the upgrade.
+    present = _existing_columns()
+    missing = [column for name, column in COLUMNS if name not in present]
+    if missing:
+        with op.batch_alter_table('tv', schema=None) as batch_op:
+            for column in missing:
+                batch_op.add_column(column)
+
+
+def downgrade():
+    present = _existing_columns()
+    to_drop = [name for name, _ in reversed(COLUMNS) if name in present]
+    if to_drop:
+        with op.batch_alter_table('tv', schema=None) as batch_op:
+            for name in to_drop:
+                batch_op.drop_column(name)

--- a/models.py
+++ b/models.py
@@ -22,6 +22,13 @@ class TV(db.Model):
     token = db.Column(db.Text, nullable=True)  # Store the TV token as text
     delete_other_images_on_upload = db.Column(db.Boolean, nullable=False, server_default=db.text("0"))
 
+    # Slideshow: rotate through an album on this TV. Off unless switched on.
+    slideshow_enabled = db.Column(db.Boolean, nullable=False, server_default=db.text("0"))
+    slideshow_album_id = db.Column(db.Integer, db.ForeignKey("album.id"), nullable=True)
+    slideshow_interval_minutes = db.Column(db.Integer, nullable=True)
+    slideshow_last_run = db.Column(db.DateTime, nullable=True)
+    slideshow_last_content_id = db.Column(db.String(255), nullable=True)
+
     uploaded_images = db.relationship(
         'UploadedImage',
         back_populates='tv',

--- a/tests/test_slideshow.py
+++ b/tests/test_slideshow.py
@@ -1,0 +1,182 @@
+"""Covers the slideshow scheduling, its art-mode guard and the settings endpoint.
+
+Run with: pytest tests/test_slideshow.py
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.environ.setdefault("FRAME_TV_DATA", os.path.join(os.path.dirname(os.path.abspath(__file__)), "_data"))
+# The loop is a background thread; the pieces below are exercised directly.
+os.environ.setdefault("FRAME_TV_SLIDESHOW", "0")
+
+import app as backend
+from utils import slideshow
+
+
+class FakeTV:
+    def __init__(self, **kwargs):
+        self.ip = "192.0.2.10"
+        self.token = "1"
+        self.slideshow_enabled = True
+        self.slideshow_album_id = 1
+        self.slideshow_interval_minutes = 30
+        self.slideshow_last_run = None
+        self.__dict__.update(kwargs)
+
+
+@pytest.fixture
+def client():
+    backend.app.config["TESTING"] = True
+    with backend.app.app_context():
+        backend.db.drop_all()
+        backend.db.create_all()
+    return backend.app.test_client()
+
+
+# --- when a TV is due ---
+
+def test_a_tv_is_due_only_once_its_interval_has_passed():
+    now = datetime(2026, 1, 1, 12, 0)
+    assert slideshow._due(FakeTV(), now), "never run yet"
+    assert not slideshow._due(FakeTV(slideshow_last_run=now - timedelta(minutes=5)), now)
+    assert slideshow._due(FakeTV(slideshow_last_run=now - timedelta(minutes=31)), now)
+
+
+@pytest.mark.parametrize("tv", [
+    FakeTV(slideshow_enabled=False),
+    FakeTV(slideshow_album_id=None),
+    FakeTV(slideshow_interval_minutes=None),
+    FakeTV(slideshow_interval_minutes=0),
+])
+def test_an_incomplete_slideshow_never_runs(tv):
+    assert not slideshow._due(tv, datetime(2026, 1, 1, 12, 0))
+
+
+# --- never interrupt someone ---
+
+def test_a_tv_in_use_is_left_alone():
+    """Showing an image switches a Frame TV to art mode, cutting across whoever is watching."""
+    asked = []
+
+    def art_mode(ip, token=None):
+        asked.append(ip)
+        return False
+
+    assert slideshow._is_showing_art(FakeTV(), art_mode, (OSError,)) is False
+    assert asked == ["192.0.2.10"], "the TV should have been asked, not assumed"
+
+
+def test_a_tv_already_showing_art_is_rotated():
+    assert slideshow._is_showing_art(FakeTV(), lambda ip, token=None: True, (OSError,)) is True
+
+
+def test_a_tv_that_cannot_be_read_is_treated_as_in_use():
+    """Skipping a rotation is harmless; interrupting one is not."""
+
+    def unreachable(ip, token=None):
+        raise OSError("no route to host")
+
+    assert slideshow._is_showing_art(FakeTV(), unreachable, (OSError,)) is False
+
+
+# --- which image comes next ---
+
+def test_the_rotation_wraps_around():
+    uploaded = [type("U", (), {"content_id": c})() for c in ("A", "B", "C")]
+    assert slideshow._next_content_id(uploaded, None) == "A"
+    assert slideshow._next_content_id(uploaded, "A") == "B"
+    assert slideshow._next_content_id(uploaded, "C") == "A", "wraps to the start"
+    assert slideshow._next_content_id(uploaded, "gone") == "A", "forgets an image that left"
+    assert slideshow._next_content_id([], "A") is None
+
+
+# --- an image the TV no longer holds ---
+
+def test_a_refused_content_id_is_dropped_rather_than_retried(client):
+    """A TV that refuses an image no longer holds it, whatever the database says.
+
+    Left in place it is requested again on every tick, which fills the log with
+    `select_image request failed with error number -10`.
+    """
+    with backend.app.app_context():
+        tv = backend.TV(ip="192.0.2.63", name="TV", token="1")
+        album = backend.Album(name="Album")
+        backend.db.session.add_all([tv, album])
+        backend.db.session.commit()
+        for filename, content_id in (("a.png", "GONE"), ("b.png", "STILL_THERE")):
+            image = backend.Image(filename=filename, album_id=album.id)
+            backend.db.session.add(image)
+            backend.db.session.commit()
+            backend.db.session.add(
+                backend.UploadedImage(image_id=image.id, tv_id=tv.id, content_id=content_id)
+            )
+        backend.db.session.commit()
+        tv_id = tv.id
+
+        removed = slideshow._forget_content(backend.db, backend.UploadedImage, tv_id, "GONE")
+        remaining = {
+            u.content_id for u in backend.UploadedImage.query.filter_by(tv_id=tv_id).all()
+        }
+
+    assert removed == 1
+    assert remaining == {"STILL_THERE"}, "only the refused one should go"
+
+
+def test_forgetting_an_unknown_content_id_is_harmless(client):
+    with backend.app.app_context():
+        tv = backend.TV(ip="192.0.2.64", name="TV", token="1")
+        backend.db.session.add(tv)
+        backend.db.session.commit()
+        assert slideshow._forget_content(backend.db, backend.UploadedImage, tv.id, "NEVER") == 0
+
+
+# --- settings ---
+
+def test_the_slideshow_cannot_be_enabled_half_configured(client):
+    with backend.app.app_context():
+        backend.db.session.add(backend.TV(ip="192.0.2.21", name="TV", token="1"))
+        backend.db.session.commit()
+
+    assert client.patch("/api/tvs/192.0.2.21", json={"slideshow_enabled": True}).status_code == 400
+
+    client.post("/api/albums", json={"name": "Rotation"})
+    album_id = client.get("/api/albums").get_json()["albums"][0]["id"]
+    res = client.patch("/api/tvs/192.0.2.21", json={
+        "slideshow_enabled": True,
+        "slideshow_album_id": album_id,
+        "slideshow_interval_minutes": 15,
+    })
+    assert res.status_code == 200
+
+    tv = client.get("/api/tvs").get_json()["tvs"][0]
+    assert tv["slideshow_enabled"] is True
+    assert tv["slideshow_interval_minutes"] == 15
+
+
+@pytest.mark.parametrize("payload", [
+    {"slideshow_interval_minutes": 0},
+    {"slideshow_interval_minutes": "soon"},
+    {"slideshow_album_id": 999},
+])
+def test_invalid_slideshow_settings_are_refused(client, payload):
+    with backend.app.app_context():
+        backend.db.session.add(backend.TV(ip="192.0.2.22", name="TV", token="1"))
+        backend.db.session.commit()
+    assert client.patch("/api/tvs/192.0.2.22", json=payload).status_code in (400, 404)
+
+
+def test_existing_tv_settings_are_untouched(client):
+    """The slideshow fields are additive; the old toggle keeps working."""
+    with backend.app.app_context():
+        backend.db.session.add(backend.TV(ip="192.0.2.23", name="TV", token="1"))
+        backend.db.session.commit()
+
+    assert client.patch("/api/tvs/192.0.2.23", json={"delete_other_images_on_upload": True}).status_code == 200
+    tv = client.get("/api/tvs").get_json()["tvs"][0]
+    assert tv["delete_other_images_on_upload"] is True
+    assert tv["slideshow_enabled"] is False

--- a/utils/slideshow.py
+++ b/utils/slideshow.py
@@ -1,0 +1,177 @@
+"""Rotate through an album on a TV, one image at a time.
+
+Runs as a background thread inside the web app rather than as a separate service, so
+there is nothing extra to deploy. gunicorn runs several workers, though, and every one
+of them imports this module: a naive thread would fire the rotation once per worker.
+A lock file decides which single process owns the loop, and the others do nothing.
+
+The loop only ever moves to an image that is already on the TV, so a rotation is one
+short `select_image` call rather than an upload.
+"""
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+try:
+    import fcntl  # POSIX only; the published image runs Linux
+except ImportError:  # pragma: no cover - Windows development
+    fcntl = None
+
+# How often the loop looks for TVs that are due. The per-TV interval is what actually
+# paces the rotation; this only bounds how late a rotation can be.
+TICK_SECONDS = 30
+
+
+def _claim_runner_slot(lock_path: Path) -> Optional[object]:
+    """Take the single runner slot, or return None when another worker holds it.
+
+    The handle is returned so it stays referenced: closing the file drops the lock,
+    which is exactly what should happen if this process dies.
+    """
+    if fcntl is None:
+        # Without flock there is no cross-process arbitration; a single-process
+        # development server is the only place this happens.
+        return object()
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = open(lock_path, "w")
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return handle
+    except OSError:
+        return None
+
+
+def _due(tv, now: datetime) -> bool:
+    interval = tv.slideshow_interval_minutes
+    if not tv.slideshow_enabled or not tv.slideshow_album_id or not interval or interval <= 0:
+        return False
+    if tv.slideshow_last_run is None:
+        return True
+    return (now - tv.slideshow_last_run).total_seconds() >= interval * 60
+
+
+def _next_content_id(uploaded, last_content_id: Optional[str]) -> Optional[str]:
+    """The entry after `last_content_id`, wrapping around."""
+    content_ids = [u.content_id for u in uploaded if u.content_id]
+    if not content_ids:
+        return None
+    if last_content_id in content_ids:
+        return content_ids[(content_ids.index(last_content_id) + 1) % len(content_ids)]
+    return content_ids[0]
+
+
+def _is_showing_art(tv, is_art_mode_on, frame_tv_errors) -> bool:
+    """Whether the TV is on art mode and can be rotated without interrupting anyone.
+
+    Selecting an image with show=True pulls a Frame TV into art mode, so a rotation
+    would cut across whatever someone is watching. A TV that cannot be read is treated
+    as in use: skipping a rotation is harmless, interrupting one is not.
+    """
+    try:
+        return bool(is_art_mode_on(tv.ip, token=tv.token))
+    except frame_tv_errors as err:
+        logger.info("Slideshow could not read art mode on TV %s: %s", tv.ip, err)
+        return False
+
+
+def _forget_content(db, UploadedImage, tv_id, content_id) -> int:
+    """Drop the record that an image sits on a TV, once the TV says otherwise.
+
+    A refused content id left in place is requested again on every tick, which is how
+    one deleted image fills the log with `select_image request failed with error
+    number -10`.
+    """
+    removed = UploadedImage.query.filter_by(tv_id=tv_id, content_id=content_id).delete(
+        synchronize_session=False
+    )
+    db.session.commit()
+    return removed
+
+
+def start(app, db, models, play_uploaded_content, is_art_mode_on, frame_tv_errors, content_gone_errors) -> None:
+    """Start the rotation loop in this process if no other worker owns it."""
+    # `flask db upgrade` imports the app too. Starting there would have the loop query
+    # tables the migration is still in the middle of altering.
+    if os.environ.get("FLASK_RUN_FROM_CLI"):
+        logger.debug("Running a CLI command; the slideshow stays out of the way")
+        return
+
+    lock_path = Path(app.config['SLIDESHOW_LOCK_PATH'])
+    slot = _claim_runner_slot(lock_path)
+    if slot is None:
+        logger.info("Another worker runs the slideshow; this one will not")
+        return
+
+    TV, Image, UploadedImage = models
+
+    def rotate_one(tv) -> None:
+        # The rotation only ever moves art that is already on screen. Nothing is
+        # recorded when skipping, so it resumes on the next tick rather than waiting
+        # out another full interval once the TV goes back to art mode.
+        if not _is_showing_art(tv, is_art_mode_on, frame_tv_errors):
+            logger.debug("TV %s is in use; leaving the slideshow paused", tv.ip)
+            return
+
+        uploaded = (
+            UploadedImage.query
+            .join(Image, UploadedImage.image_id == Image.id)
+            .filter(
+                UploadedImage.tv_id == tv.id,
+                Image.album_id == tv.slideshow_album_id,
+            )
+            .order_by(UploadedImage.id)
+            .all()
+        )
+        content_id = _next_content_id(uploaded, tv.slideshow_last_content_id)
+        if not content_id:
+            logger.info(
+                "Slideshow for TV %s has nothing to show: send the album to the TV first", tv.ip
+            )
+            # Recorded anyway, so an empty album does not retry every tick.
+            tv.slideshow_last_run = datetime.now()
+            db.session.commit()
+            return
+
+        try:
+            play_uploaded_content(tv.ip, content_id, token=tv.token)
+        except content_gone_errors as err:
+            # The TV refused the image rather than failing to answer — it no longer
+            # holds that content id, whatever this database still says. Forgetting it
+            # is what stops the loop retrying the same dead entry every tick.
+            logger.info("TV %s no longer holds %s, forgetting it: %s", tv.ip, content_id, err)
+            _forget_content(db, UploadedImage, tv.id, content_id)
+            return
+        except frame_tv_errors as err:
+            # An unreachable TV is expected — it may simply be off. Try again next tick.
+            logger.info("Slideshow could not reach TV %s: %s", tv.ip, err)
+            return
+
+        tv.slideshow_last_content_id = content_id
+        tv.slideshow_last_run = datetime.now()
+        db.session.commit()
+        logger.info("Slideshow moved TV %s to %s", tv.ip, content_id)
+
+    def loop() -> None:
+        # Keeps the lock handle alive for as long as the loop runs.
+        _ = slot
+        time.sleep(TICK_SECONDS)
+        while True:
+            try:
+                with app.app_context():
+                    now = datetime.now()
+                    for tv in TV.query.filter_by(slideshow_enabled=True).all():
+                        if _due(tv, now):
+                            rotate_one(tv)
+            except Exception:
+                logger.exception("Slideshow tick failed")
+            time.sleep(TICK_SECONDS)
+
+    threading.Thread(target=loop, name="frametv-slideshow", daemon=True).start()
+    logger.info("Slideshow runner started in this worker")


### PR DESCRIPTION
Follow-up to #62/#63/#64. Point a TV at an album and an interval, and it moves to the next image on its own.

### What it does

A per-TV setting in **TV Settings**: pick an album, pick an interval in minutes. The loop only moves between images **already uploaded to that TV**, so a rotation is one short `select_image` call, not an upload.

### Two things this learned from running on a real TV

**It never interrupts anyone.** Selecting an image with `show=True` pulls a Frame TV into art mode, so an unguarded rotation cuts across whatever is on screen. Art mode is checked first, and a TV that is in use — or that cannot be read — is left alone. Nothing is recorded when skipping, so the rotation resumes as soon as the TV is back on art mode instead of waiting out another full interval.

**It forgets images the TV no longer holds.** A TV that refuses a content id does not have that image any more, whatever the database says. Retrying it every tick is what fills the log with `select_image request failed with error number -10`; the record is dropped instead and the rotation carries on.

Both of these were found in use, not in testing.

### Running under gunicorn

Every worker imports the app, so a naive thread would fire the rotation four times over. A lock file elects the single process that owns the loop. It also stays out of `flask db upgrade`, which imports the app too and would otherwise query tables mid-migration.

`FRAME_TV_SLIDESHOW=0` keeps the loop from starting at all.

### Compatibility

The migration only adds nullable columns to `tv`, plus one defaulting to off, so an existing database behaves exactly as before until a slideshow is configured. It checks before adding, since `create_all()` may already have created them on a fresh install.

Verified both paths in a container: a fresh install, and a database created by current `main` then upgraded — columns usable, app boots, existing settings untouched.

41 tests pass, frontend typechecks and builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)