### PR TITLE
fix: Let a deliberate action wait its turn when the TV is busy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ All optional, with sensible defaults. Set them as environment variables on the c
 | `FRAME_TV_UPLOAD_DEADLINE` | `120` | Same, for image uploads, which push the whole file to the TV. |
 | `FRAME_TV_PAIRING_TIMEOUT` | `45` | How long adding a TV waits for the pairing prompt to be accepted. |
 | `FRAME_TV_DOWN_COOLDOWN` | `30` | Seconds a TV is skipped after it failed to answer. |
+| `FRAME_TV_BUSY_WAIT` | `90` | How long a deliberate action queues behind another operation on the same TV. |
 | `FRAME_TV_MAX_PARALLEL_CALLS` | `8` | Concurrent TV requests per worker. |
 
 # Tests
@@ -106,6 +107,13 @@ Deliberate actions (playing an image, deleting one, uploading) ignore that coold
 still try, so the TV waking up is noticed immediately. If it persists, check that the TV is
 on and reachable, then look for a single `Timeout after …` line in the logs: the skipped
 requests that follow are deliberately silent.
+
+## "The TV is busy with another request"
+
+Something else was talking to that TV — most often a page of thumbnails still loading,
+which holds the set for far longer than a single request. A deliberate action queues for
+`FRAME_TV_BUSY_WAIT` seconds before giving up; nothing was changed on the TV, so retrying
+once the other operation has finished is all it needs.
 
 ## Errors when uploading images to the TV:
 

--- a/app.py
+++ b/app.py
@@ -621,6 +621,12 @@ def api_remove_all_tv_images(ip):
     try:
         delete_all_images_from_tv(ip, token=tv.token)
         return jsonify({'success': True})
+    except FrameTVUnavailableError as e:
+        # Another operation held the TV for the whole wait — nothing was deleted, and
+        # retrying once the TV is free is all this needs.
+        db.session.rollback()
+        app.logger.info('Could not remove all images: %s', e)
+        return jsonify({'error': 'The TV is busy with another request, try again', 'tv_busy': True}), 503
     except Exception as e:
         db.session.rollback()
         _log_exception('Failed to remove all images from TV', e)

--- a/tests/test_frame_tv_timeouts.py
+++ b/tests/test_frame_tv_timeouts.py
@@ -160,6 +160,39 @@ def test_a_second_tv_is_not_held_up_by_the_first():
     holder.join(timeout=10)
 
 
+def test_a_deliberate_action_queues_behind_a_long_read(monkeypatch):
+    """A page of thumbnails holds the TV far longer than one call's deadline.
+
+    The background read gives up as soon as its own budget is gone, so it cannot tie up
+    a worker; the deliberate action waits for its turn instead of failing.
+    """
+    monkeypatch.setattr(frame_tv, "TV_BUSY_WAIT", 5)
+
+    holding = threading.Event()
+    holder = threading.Thread(
+        target=lambda: frame_tv._tv_call(
+            "192.0.2.20",
+            "holding",
+            lambda s: (holding.set(), time.sleep(0.8)),
+            open_remote=False,
+            skip_when_down=False,
+        )
+    )
+    holder.start()
+    assert holding.wait(timeout=5), "the holder never started"
+
+    with pytest.raises(FrameTVUnavailableError):
+        frame_tv._tv_call(
+            "192.0.2.20", "reading", lambda s: "never", open_remote=False, deadline=0.2
+        )
+
+    assert frame_tv._tv_call(
+        "192.0.2.20", "deleting", lambda s: "done", open_remote=False,
+        deadline=0.2, skip_when_down=False,
+    ) == "done"
+    holder.join(timeout=10)
+
+
 def test_the_unavailable_error_stays_a_connection_error():
     """Existing handlers catch FrameTVConnectionError; the new type must not escape them."""
     assert issubclass(FrameTVUnavailableError, FrameTVConnectionError)

--- a/utils/frame_tv.py
+++ b/utils/frame_tv.py
@@ -36,6 +36,10 @@ TV_PAIRING_TIMEOUT = _env_int("FRAME_TV_PAIRING_TIMEOUT", 45)
 # How long a TV is skipped after it failed to answer, so one dead set cannot
 # turn a page full of thumbnails into a page full of stuck requests.
 TV_DOWN_COOLDOWN = _env_int("FRAME_TV_DOWN_COOLDOWN", 30)
+# How long a deliberate action queues behind another operation on the same TV. A page
+# of thumbnails holds the TV for far longer than one call's deadline, and someone who
+# pressed a button would rather wait for their turn than be told the TV is busy.
+TV_BUSY_WAIT = _env_int("FRAME_TV_BUSY_WAIT", 90)
 # Simple in-memory cache to reduce repeated TV requests
 # Structure: { (ip, 'gallery'): (timestamp, value), (ip, content_id): (timestamp, bytes) }
 _CACHE: dict = {}
@@ -215,7 +219,9 @@ def _local_tv_lock(ip: str) -> threading.Lock:
 def _tv_exclusive(ip: str, wait: float):
     """Hold a TV for one operation at a time, across threads and gunicorn workers."""
     give_up_at = time.monotonic() + wait
-    busy = FrameTVUnavailableError(f"TV {ip} is busy with another request")
+    busy = FrameTVUnavailableError(
+        f"TV {ip} stayed busy with another request for more than {wait:.0f}s"
+    )
 
     local = _local_tv_lock(ip)
     if not local.acquire(timeout=max(0.0, wait)):
@@ -310,8 +316,11 @@ def _tv_call(
             f"TV {ip} did not answer recently; skipping {action_description} it for another {cooldown:.0f}s"
         )
 
-    # One operation at a time per TV: concurrent art channels corrupt each other.
-    with _tv_exclusive(ip, wait=deadline):
+    # One operation at a time per TV: concurrent art channels corrupt each other. The
+    # same split as the cooldown applies to the queue: a background read gives up as
+    # soon as its own deadline is gone, a deliberate action waits for its turn.
+    busy_wait = deadline if skip_when_down else max(deadline, TV_BUSY_WAIT)
+    with _tv_exclusive(ip, wait=busy_wait):
         session = _TVSession(ip, token, DEFAULT_TIMEOUT)
 
         def run():


### PR DESCRIPTION
Found while using the app: pressing **Remove all images** in TV Settings while the TV gallery was still loading its thumbnails failed with a traceback and a 500.

```
FrameTVUnavailableError: TV 10.0.0.13 is busy with another request
```

### Why

A Frame TV serves one art channel, so operations on a TV are serialised — that part is correct. But the queue wait used the same budget as the TV call itself (`FRAME_TV_CALL_DEADLINE`, 20s). A page of thumbnails holds the set for much longer than 20s, so anything the user pressed meanwhile was rejected rather than queued.

Waiting for your turn is not the same as the TV being slow, so it gets its own budget:

```python
busy_wait = deadline if skip_when_down else max(deadline, TV_BUSY_WAIT)
```

This reuses the split `skip_when_down` already draws. A background read (thumbnails, gallery listing) gives up as soon as its own deadline is gone, so it can never tie up a worker. A deliberate action — delete, play, upload — waits up to `FRAME_TV_BUSY_WAIT` (90s, configurable) for its turn.

Worst case is 90s queued + 20s of call, comfortably under the 180s gunicorn timeout.

The delete-all endpoint also answers 503 with a retry hint instead of logging a traceback: nothing failed, the TV was simply taken.

### Verification

One test covers both sides — the background read gives up, the deliberate action gets through. It fails without the change:

```
FAILED test_a_deliberate_action_queues_behind_a_long_read
E   FrameTVUnavailableError: TV 192.0.2.20 stayed busy ... for more than 0s
```

26 tests pass. Running on a real TV since this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)