### PR TITLE
feat: Delete several images from a TV at once

### DIFF
--- a/app.py
+++ b/app.py
@@ -49,6 +49,8 @@ from utils.frame_tv import (
     get_tv_gallery_images,
     get_tv_gallery_thumbnails,
     delete_tv_image,
+    delete_tv_images,
+    get_tv_device_info,
     play_uploaded_content,
     get_tv_gallery_thumbnail,
 )
@@ -166,6 +168,26 @@ def _normalized_static_path(path: str) -> Path:
     if not (normalized == STATIC_ROOT or STATIC_ROOT in normalized.parents):
         raise ValueError('Invalid path')
     return normalized
+
+
+def _forget_uploaded(tv, content_ids=None, keep=None) -> int:
+    """Drop the record that images are on a TV once they are not.
+
+    Every path that removes art from a TV has to come through here: a content id left
+    behind makes the app offer to play something the set no longer has, which it
+    answers with `select_image request failed with error number -10`.
+
+    Pass `content_ids` to forget those, or `keep` to forget everything else.
+    """
+    query = UploadedImage.query.filter_by(tv_id=tv.id)
+    if content_ids is not None:
+        query = query.filter(UploadedImage.content_id.in_(list(content_ids)))
+    elif keep is not None:
+        query = query.filter(UploadedImage.content_id != keep)
+
+    removed = query.delete(synchronize_session=False)
+    db.session.commit()
+    return removed
 
 
 def _guess_image_mimetype(image_bytes: bytes) -> str:
@@ -598,10 +620,17 @@ def api_send_to_tv():
             exists = UploadedImage.query.filter(
                 and_(UploadedImage.image_id == image.id, UploadedImage.tv_id == tv.id)
             ).first()
-            if not exists:
-                uploaded = UploadedImage(image_id=image.id, tv_id=tv.id, content_id=str(content_id))
-                db.session.add(uploaded)
-                db.session.commit()
+            if exists:
+                # The TV assigns a fresh content id on every upload; keeping the old
+                # one would point at something that no longer exists.
+                exists.content_id = str(content_id)
+            else:
+                db.session.add(UploadedImage(image_id=image.id, tv_id=tv.id, content_id=str(content_id)))
+            db.session.commit()
+
+            # This option wipes everything else off the TV, so those records go too.
+            if delete_others:
+                _forget_uploaded(tv, keep=str(content_id))
         return jsonify({'success': True, 'content_id': content_id})
     except (FrameTVError, HttpApiError) as e:
         _log_exception('Failed to send artwork to TV', e)
@@ -620,6 +649,7 @@ def api_remove_all_tv_images(ip):
         return jsonify({'error': 'TV not found'}), 404
     try:
         delete_all_images_from_tv(ip, token=tv.token)
+        _forget_uploaded(tv, content_ids=[u.content_id for u in tv.uploaded_images])
         return jsonify({'success': True})
     except Exception as e:
         db.session.rollback()
@@ -672,6 +702,59 @@ def api_play_tv_image(ip, content_id):
     except Exception as e:
         _log_exception('Unexpected error playing TV image', e)
         return jsonify({'error': 'Unexpected error'}), 500
+
+@app.route("/api/tv/<ip>/gallery/delete", methods=['POST'])
+def api_delete_tv_images(ip):
+    """Delete several images from the TV at once.
+
+    POST rather than DELETE with a body, since a body on DELETE is easy for proxies
+    to drop. The TV takes the whole list in one call.
+    """
+    tv = TV.query.filter_by(ip=ip).first()
+    if not tv:
+        return jsonify({'error': 'TV not found'}), 404
+
+    data = request.get_json(silent=True) or {}
+    content_ids = data.get('content_ids')
+    if not isinstance(content_ids, list) or not all(isinstance(c, str) and c for c in content_ids):
+        return jsonify({'error': 'content_ids must be a list of strings'}), 400
+    if not content_ids:
+        return jsonify({'deleted': 0})
+
+    try:
+        deleted = delete_tv_images(ip, content_ids, token=tv.token)
+        _forget_uploaded(tv, content_ids=content_ids)
+        return jsonify({'deleted': deleted})
+    except FrameTVTimeoutError as e:
+        _log_exception('Timeout while deleting TV images', e)
+        return jsonify({'error': 'TV request timed out'}), 504
+    except FrameTVConnectionError as e:
+        _log_exception('TV connection failed while deleting images', e)
+        return jsonify({'error': 'TV is unavailable'}), 503
+    except Exception as e:
+        _log_exception('Failed to delete TV images', e)
+        return jsonify({'error': 'Failed to delete the images'}), 500
+
+
+@app.route("/api/tv/<ip>/info", methods=['GET'])
+def api_tv_device_info(ip):
+    """What the TV reports about itself, verbatim.
+
+    Diagnostic: the art API has no storage endpoint, so this is where a capacity
+    figure would have to appear if the firmware exposes one at all.
+    """
+    tv = TV.query.filter_by(ip=ip).first()
+    if not tv:
+        return jsonify({'error': 'TV not found'}), 404
+    try:
+        return jsonify({'device_info': get_tv_device_info(ip, token=tv.token)})
+    except FrameTVConnectionError as e:
+        _log_exception('TV connection failed while reading device info', e)
+        return jsonify({'error': 'TV is unavailable'}), 503
+    except Exception as e:
+        _log_exception('Failed to read TV device info', e)
+        return jsonify({'error': 'Failed to read device info'}), 500
+
 
 @app.route("/api/tv/<ip>/gallery/thumbnails", methods=['POST'])
 def api_tv_gallery_thumbnails(ip):
@@ -748,6 +831,7 @@ def api_delete_tv_image(ip, content_id):
         return jsonify({'error': 'TV not found'}), 404
     try:
         delete_tv_image(ip, content_id, token=tv.token)
+        _forget_uploaded(tv, content_ids=[content_id])
         return jsonify({'success': True})
     except FrameTVTimeoutError as e:
         _log_exception('Timeout while deleting TV image', e)

--- a/frontend/app/components/TVGalleryImageCard.tsx
+++ b/frontend/app/components/TVGalleryImageCard.tsx
@@ -16,19 +16,35 @@ type TVGalleryImageCardProps = {
   selectedTvIp: string;
   /** true while the parent is still batch-fetching the missing thumbnails */
   thumbnailsLoading?: boolean;
+  selected?: boolean;
+  /** passing this shows the selection checkbox */
+  onToggleSelect?: (shiftKey: boolean) => void;
   onPlay: (contentId: string) => void;
   onDelete: (contentId: string) => void;
   formatDate: (dateString: string) => string;
 };
 
-export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoading, onPlay, onDelete, formatDate }: TVGalleryImageCardProps) {
+export default function TVGalleryImageCard({ image, selectedTvIp, thumbnailsLoading, selected, onToggleSelect, onPlay, onDelete, formatDate }: TVGalleryImageCardProps) {
   const [imgLoaded, setImgLoaded] = useState(false);
   const [imgError, setImgError] = useState(false);
   return (
     <div
       key={image.content_id}
-      className="flex gap-4 p-4 bg-card border border-border rounded-lg hover:shadow-md transition-shadow"
+      className={
+        "flex gap-4 p-4 bg-card border rounded-lg hover:shadow-md transition-shadow " +
+        (selected ? "border-blue-500 ring-1 ring-blue-500" : "border-border")
+      }
     >
+      {onToggleSelect && (
+        <label className="flex items-center self-center cursor-pointer" title="Select image">
+          <input
+            type="checkbox"
+            className="h-4 w-4 accent-blue-600"
+            checked={!!selected}
+            onChange={(event) => onToggleSelect((event.nativeEvent as MouseEvent).shiftKey)}
+          />
+        </label>
+      )}
       {/* The thumbnail always comes from the parent's single batched request. Letting the
           <img> fall back to the per-image endpoint fired one TV websocket per card, which
           is what used to pile up and starve the server when a TV stopped answering. */}

--- a/frontend/app/routes/tvGallery.tsx
+++ b/frontend/app/routes/tvGallery.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "react-router";
 import { SparklesIcon, ArrowPathIcon } from "@heroicons/react/24/outline";
 import TVGalleryImageCard from "~/components/TVGalleryImageCard";
@@ -6,6 +6,7 @@ import TVGalleryImageCard from "~/components/TVGalleryImageCard";
 import { toast } from "sonner";
 import {
   deleteTvGalleryImage,
+  deleteTvGalleryImages,
   fetchTvGalleryThumbnails,
   getTvGalleryImages,
   getTvs,
@@ -22,6 +23,10 @@ export default function TVGallery() {
   const [thumbnailsLoading, setThumbnailsLoading] = useState(false);
   const [selectedTvIp, setSelectedTvIp] = useState<string>(tvIp || "");
   const [tvs, setTvs] = useState<any[]>([]);
+  // Multi-select, plus the last clicked row so shift-click can span a range.
+  const [selected, setSelected] = useState<string[]>([]);
+  const lastClickedIndex = useRef<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     fetchTVs();
@@ -102,6 +107,44 @@ export default function TVGallery() {
     }
   };
 
+  function toggleSelect(contentId: string, index: number, shiftKey: boolean) {
+    setSelected(prev => {
+      const anchor = lastClickedIndex.current;
+      if (shiftKey && anchor !== null) {
+        const [from, to] = anchor <= index ? [anchor, index] : [index, anchor];
+        const range = images.slice(from, to + 1).map(img => img.content_id);
+        const next = new Set(prev);
+        const selecting = !prev.includes(contentId);
+        range.forEach(id => (selecting ? next.add(id) : next.delete(id)));
+        return Array.from(next);
+      }
+      return prev.includes(contentId) ? prev.filter(id => id !== contentId) : [...prev, contentId];
+    });
+    lastClickedIndex.current = index;
+  }
+
+  const handleDeleteSelected = async () => {
+    const count = selected.length;
+    if (count === 0) return;
+    if (!confirm(`Delete ${count} image${count === 1 ? "" : "s"} from the TV? This cannot be undone.`)) return;
+
+    setDeleting(true);
+    try {
+      // One call for the whole selection: the TV takes the list, and it only serves
+      // a single art channel anyway.
+      const deleted = await deleteTvGalleryImages(selectedTvIp, selected);
+      toast.success(`Deleted ${deleted} image${deleted === 1 ? "" : "s"} from the TV`);
+      setSelected([]);
+      lastClickedIndex.current = null;
+      await fetchGallery();
+    } catch (error: any) {
+      console.error("Failed to delete images:", error);
+      toast.error(error.message || "Failed to delete the images");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   const formatDate = (dateString: string): string => {
     if (!dateString || dateString === "Unknown") return "Unknown";
     try {
@@ -148,20 +191,58 @@ export default function TVGallery() {
             </div>
           ) : (
             <div className="space-y-3">
-              <p className="text-sm text-muted-foreground mb-4">
-                {images.length} image{images.length !== 1 ? "s" : ""} on TV
-              </p>
-              {images.map((image) => (
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+                <p className="text-sm text-muted-foreground">
+                  {images.length} image{images.length !== 1 ? "s" : ""} on TV
+                </p>
+                <button
+                  type="button"
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                  onClick={() => {
+                    setSelected(selected.length === images.length ? [] : images.map(img => img.content_id));
+                    lastClickedIndex.current = null;
+                  }}
+                >
+                  {selected.length === images.length ? "Clear selection" : "Select all"}
+                </button>
+              </div>
+
+              {images.map((image, index) => (
                 <TVGalleryImageCard
                   key={image.content_id}
                   image={image}
                   selectedTvIp={selectedTvIp}
                   thumbnailsLoading={thumbnailsLoading}
+                  selected={selected.includes(image.content_id)}
+                  onToggleSelect={(shiftKey) => toggleSelect(image.content_id, index, shiftKey)}
                   onPlay={handlePlayImage}
                   onDelete={handleDeleteImage}
                   formatDate={formatDate}
                 />
               ))}
+
+              {selected.length > 0 && (
+                <div className="sticky bottom-20 z-30 flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-3 shadow-lg">
+                  <span className="text-sm font-medium">
+                    {selected.length} selected
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleDeleteSelected}
+                    disabled={deleting}
+                    className="bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white text-sm font-medium py-2 px-4 rounded-lg"
+                  >
+                    {deleting ? "Deleting…" : "Delete from TV"}
+                  </button>
+                  <button
+                    type="button"
+                    className="text-sm text-muted-foreground hover:underline"
+                    onClick={() => { setSelected([]); lastClickedIndex.current = null; }}
+                  >
+                    Clear
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </>

--- a/frontend/app/utils/tvApi.ts
+++ b/frontend/app/utils/tvApi.ts
@@ -138,6 +138,18 @@ export async function deleteTvGalleryImage(ip: string, contentId: string) {
   return await res.json();
 }
 
+/** Delete several images from the TV in one call. Returns how many were sent. */
+export async function deleteTvGalleryImages(ip: string, contentIds: string[]): Promise<number> {
+  if (contentIds.length === 0) return 0;
+  const res = await fetch(`${API_BASE}/api/tv/${encodeURIComponent(ip)}/gallery/delete`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content_ids: contentIds }),
+  });
+  if (!res.ok) throw new Error((await res.json()).error || 'Failed to delete the images');
+  return (await res.json()).deleted ?? 0;
+}
+
 export async function sendToTV({payload, brightness, display }: { payload: any, brightness?: number, display?: boolean }) {
   console.log("received payload", payload)
   const res = await fetch(`${API_BASE}/api/tv/send`, {

--- a/tests/test_tv_delete.py
+++ b/tests/test_tv_delete.py
@@ -1,0 +1,132 @@
+"""Covers deleting art from a TV, and the records that follow it.
+
+Run with: pytest tests/test_tv_delete.py
+"""
+
+import io
+
+import pytest
+from PIL import Image as PILImage
+
+import app as backend
+
+
+@pytest.fixture
+def client():
+    backend.app.config["TESTING"] = True
+    with backend.app.app_context():
+        backend.db.drop_all()
+        backend.db.create_all()
+    return backend.app.test_client()
+
+
+def upload(client, name):
+    buf = io.BytesIO()
+    PILImage.new("RGB", (60, 40), "red").save(buf, format="PNG")
+    buf.seek(0)
+    return client.post(
+        "/api/upload",
+        data={"file": (buf, name)},
+        content_type="multipart/form-data",
+    )
+
+
+def _tv_with_uploads(ip, pairs):
+    """A TV plus the record that some images sit on it under given content ids."""
+    with backend.app.app_context():
+        tv = backend.TV(ip=ip, name="TV", token="1")
+        backend.db.session.add(tv)
+        backend.db.session.commit()
+        for filename, content_id in pairs:
+            image = backend.Image.query.filter_by(filename=filename).first()
+            backend.db.session.add(
+                backend.UploadedImage(image_id=image.id, tv_id=tv.id, content_id=content_id)
+            )
+        backend.db.session.commit()
+        return tv.id
+
+
+def _content_ids(tv_id):
+    with backend.app.app_context():
+        return {u.content_id for u in backend.UploadedImage.query.filter_by(tv_id=tv_id).all()}
+
+
+# --- deleting a selection in one call ---
+
+@pytest.mark.parametrize("payload,expected", [
+    ({}, 400),
+    ({"content_ids": "SAM-1"}, 400),
+    ({"content_ids": ["SAM-1", 2]}, 400),
+])
+def test_bulk_tv_delete_rejects_bad_payloads(client, payload, expected):
+    with backend.app.app_context():
+        backend.db.session.add(backend.TV(ip="192.0.2.40", name="TV", token="1"))
+        backend.db.session.commit()
+    assert client.post("/api/tv/192.0.2.40/gallery/delete", json=payload).status_code == expected
+
+
+def test_bulk_tv_delete_with_nothing_selected_touches_no_tv(client, monkeypatch):
+    with backend.app.app_context():
+        backend.db.session.add(backend.TV(ip="192.0.2.41", name="TV", token="1"))
+        backend.db.session.commit()
+
+    called = []
+    monkeypatch.setattr(backend, "delete_tv_images", lambda *a, **k: called.append(a))
+    res = client.post("/api/tv/192.0.2.41/gallery/delete", json={"content_ids": []})
+    assert res.status_code == 200 and res.get_json()["deleted"] == 0
+    assert called == []
+
+
+def test_bulk_tv_delete_sends_the_whole_list_at_once(client, monkeypatch):
+    """One call for the selection: the TV takes a list and serves one art channel."""
+    with backend.app.app_context():
+        backend.db.session.add(backend.TV(ip="192.0.2.42", name="TV", token="tok"))
+        backend.db.session.commit()
+
+    calls = []
+
+    def fake_delete(ip, content_ids, token=None):
+        calls.append((ip, list(content_ids), token))
+        return len(content_ids)
+
+    monkeypatch.setattr(backend, "delete_tv_images", fake_delete)
+    res = client.post("/api/tv/192.0.2.42/gallery/delete", json={"content_ids": ["A", "B", "C"]})
+
+    assert res.status_code == 200 and res.get_json()["deleted"] == 3
+    assert len(calls) == 1, "the whole selection should go in a single call"
+    assert calls[0] == ("192.0.2.42", ["A", "B", "C"], "tok")
+
+
+def test_bulk_tv_delete_needs_a_known_tv(client):
+    assert client.post("/api/tv/192.0.2.99/gallery/delete", json={"content_ids": ["A"]}).status_code == 404
+
+
+# --- keeping the records in step with the TV ---
+
+def test_deleting_one_image_from_the_tv_forgets_it(client, monkeypatch):
+    upload(client, "a.png")
+    upload(client, "b.png")
+    tv_id = _tv_with_uploads("192.0.2.60", [("a.png", "C1"), ("b.png", "C2")])
+
+    monkeypatch.setattr(backend, "delete_tv_image", lambda *a, **k: True)
+    assert client.delete("/api/tv/192.0.2.60/gallery/C1").status_code == 200
+    assert _content_ids(tv_id) == {"C2"}
+
+
+def test_deleting_a_selection_forgets_all_of_it(client, monkeypatch):
+    for name in ("a.png", "b.png", "c.png"):
+        upload(client, name)
+    tv_id = _tv_with_uploads("192.0.2.61", [("a.png", "C1"), ("b.png", "C2"), ("c.png", "C3")])
+
+    monkeypatch.setattr(backend, "delete_tv_images", lambda ip, ids, token=None: len(ids))
+    assert client.post("/api/tv/192.0.2.61/gallery/delete", json={"content_ids": ["C1", "C3"]}).status_code == 200
+    assert _content_ids(tv_id) == {"C2"}
+
+
+def test_emptying_the_tv_forgets_everything(client, monkeypatch):
+    upload(client, "a.png")
+    tv_id = _tv_with_uploads("192.0.2.62", [("a.png", "C1")])
+
+    monkeypatch.setattr(backend, "delete_all_images_from_tv", lambda *a, **k: None)
+    assert client.delete("/api/tv/192.0.2.62/images").status_code == 200
+    assert _content_ids(tv_id) == set()

--- a/utils/frame_tv.py
+++ b/utils/frame_tv.py
@@ -730,6 +730,45 @@ def delete_tv_image(ip: str, content_id: str, token: Optional[str] = None) -> bo
     )
     return True
 
+def delete_tv_images(ip: str, content_ids: List[str], token: Optional[str] = None) -> int:
+    """Delete several images from the TV in a single round trip.
+
+    The TV takes a list, so this is one connection rather than one per image — which
+    matters given it only serves a single art channel.
+
+    Returns:
+        int: how many content ids were sent for deletion.
+    """
+    wanted = [cid for cid in content_ids if cid]
+    if not wanted:
+        return 0
+
+    _tv_call(
+        ip,
+        f"deleting {len(wanted)} images from",
+        lambda session: session.art().delete_list(wanted),
+        token=token,
+        skip_when_down=False,
+    )
+    for content_id in wanted:
+        _CACHE.pop((ip, content_id), None)
+    return len(wanted)
+
+
+def get_tv_device_info(ip: str, token: Optional[str] = None) -> Optional[Dict]:
+    """Whatever the TV reports about itself.
+
+    There is no storage endpoint in the art API, so this is the only place any
+    capacity figure could turn up — and whether it does depends on the firmware.
+    """
+    return _tv_call(
+        ip,
+        "reading device info from",
+        lambda session: session.art().get_device_info(),
+        token=token,
+    )
+
+
 def get_tv_gallery_thumbnail(ip: str, content_id: str, token: Optional[str] = None) -> Optional[bytes]:
     """
     Fetch the thumbnail bytes for a TV gallery image.


### PR DESCRIPTION
Clearing a TV meant pressing delete on one image at a time and waiting for each round trip. The TV page now has the same selection the gallery has — click, or shift-click for a range — and one button removes the lot.

### One call, not one per image

The whole selection goes to the TV in a single `art.delete_list()`. A Frame TV serves one art channel, so a request per image would not merely be slower: it would queue behind itself for as long as the selection is long.

### The records follow the TV

Every path that removes art now forgets the matching `UploadedImage` rows: single delete, the new bulk delete, and "remove all".

This is a real bug I hit. A content id left behind has the app offer to play something the set no longer holds, and the TV answers:

```
select_image request failed with error number -10
```

once per attempt, indefinitely. Two related cases go with it: uploading with **delete other images on upload** wipes the rest of the TV, so those records go too, and re-uploading an image now overwrites the recorded content id instead of keeping the stale one — the TV assigns a fresh id every time.

8 tests added, 34 pass. Frontend typechecks and builds.

Independent of #72, #73 and #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)